### PR TITLE
More authentication fixes

### DIFF
--- a/src/app/auth/auth.guard.spec.ts
+++ b/src/app/auth/auth.guard.spec.ts
@@ -11,7 +11,7 @@ describe('authGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) =>
     TestBed.runInInjectionContext(() => authGuard(...guardParameters));
 
-  const prepareGuard = (isAuthenticated: boolean) => {
+  const prepareGuard = (checkAuthenticated: boolean) => {
     TestBed.configureTestingModule({
       providers: [
         {
@@ -20,7 +20,7 @@ describe('authGuard', () => {
         },
         {
           provide: AuthService,
-          useValue: { isAuthenticated: async () => Promise.resolve(isAuthenticated) },
+          useValue: { checkAuthenticated: async () => Promise.resolve(checkAuthenticated) },
         },
       ],
     });

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -6,7 +6,7 @@ export const authGuard: CanActivateFn = async () => {
   const authService: AuthService = inject(AuthService);
   const router: Router = inject(Router);
 
-  if (await authService.isAuthenticated()) {
+  if (await authService.checkAuthenticated()) {
     return true;
   }
   return router.navigateByUrl('login');

--- a/src/app/components/layout/header/header.component.spec.ts
+++ b/src/app/components/layout/header/header.component.spec.ts
@@ -14,7 +14,7 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     const fakeAppInsightsService = {};
     fakeAuthService = {
-      isAuthenticated: jasmine.createSpy().and.resolveTo(true),
+      getAuthenticated: jasmine.createSpy().and.returnValue(true),
       logout: jasmine.createSpy().and.resolveTo(),
     };
 
@@ -34,7 +34,7 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    expect(fakeAuthService.isAuthenticated).toHaveBeenCalled();
+    expect(fakeAuthService.getAuthenticated).toHaveBeenCalled();
   });
 
   it('logout', async () => {

--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DoCheck } from '@angular/core';
 import { AuthService } from 'src/app/services/auth/auth.service';
 
 @Component({
@@ -6,13 +6,13 @@ import { AuthService } from 'src/app/services/auth/auth.service';
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
 })
-export class HeaderComponent implements OnInit {
+export class HeaderComponent implements DoCheck {
   isAuthenticated = false;
 
   constructor(private authService: AuthService) {}
 
-  async ngOnInit() {
-    this.isAuthenticated = await this.authService.isAuthenticated();
+  ngDoCheck() {
+    this.isAuthenticated = this.authService.getAuthenticated();
   }
 
   async logout() {

--- a/src/app/components/login/login.component.spec.ts
+++ b/src/app/components/login/login.component.spec.ts
@@ -9,7 +9,7 @@ describe('LoginComponent', () => {
 
   beforeEach(() => {
     fakeAuthService = {
-      isAuthenticated: jasmine.createSpy().and.resolveTo(true),
+      checkAuthenticated: jasmine.createSpy().and.resolveTo(true),
     };
 
     TestBed.configureTestingModule({

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -11,7 +11,7 @@ export class LoginComponent implements OnInit {
   constructor(private router: Router, public authService: AuthService) {}
 
   async ngOnInit(): Promise<void> {
-    if (await this.authService.isAuthenticated()) {
+    if (await this.authService.checkAuthenticated()) {
       this.router.navigateByUrl('');
     }
   }

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -29,12 +29,12 @@ describe('AuthService', () => {
   describe('#isAuthenticated', () => {
     it('true', async () => {
       httpClientSpy.get.and.returnValue(of({}));
-      expect(await authService.isAuthenticated()).toBeTrue();
+      expect(await authService.checkAuthenticated()).toBeTrue();
     });
 
     it('false', async () => {
       httpClientSpy.get.and.returnValue(of());
-      expect(await authService.isAuthenticated()).toBeFalsy();
+      expect(await authService.checkAuthenticated()).toBeFalsy();
     });
   });
 

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -11,16 +11,23 @@ const LOGOUT_PATH = '/auth/logout';
   providedIn: 'root',
 })
 export class AuthService {
+  private authenticated = false;
+
   constructor(private readonly http: HttpClient, private router: Router, @Inject('Window') private window: Window) {}
 
-  async isAuthenticated(): Promise<boolean> {
+  getAuthenticated(): boolean {
+    return this.authenticated;
+  }
+
+  async checkAuthenticated(): Promise<boolean> {
     try {
       // add timestamp to the second to be doubly-sure we are preventing caching
       await lastValueFrom(this.http.get(`${IS_AUTH_PATH}?t=${moment().format('YYYYMMDDHHmmss')}`));
-      return true;
+      this.authenticated = true;
     } catch (err) {
-      return false;
+      this.authenticated = false;
     }
+    return this.authenticated;
   }
 
   async logout(): Promise<void> {


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

- avoid calling `/is-authenticated` lots of times
- only doing it on the auth guard
- everywhere else just checks a stored value

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
