### PR TITLE
dmp-625 : feat : add display condition to outro text

### DIFF
--- a/server/controllers/auth.ts
+++ b/server/controllers/auth.ts
@@ -11,7 +11,7 @@ function getAzureAdLogin(req: Request, res: Response): void {
   res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
   // do this whilst the page is being developed to prevent caching on the platform
   res.header('Cache-Control', 'no-store, must-revalidate');
-  res.render('azuread-b2c-login.html', { hostname: config.get('hostname') });
+  res.render('azuread-b2c-login.html', { hostname: config.get('hostname'), screen: req.query.screenName });
 }
 
 export function init(): Router {
@@ -19,3 +19,4 @@ export function init(): Router {
   router.get('/auth/azuread-b2c-login', getAzureAdLogin);
   return router;
 }
+

--- a/server/controllers/auth.ts
+++ b/server/controllers/auth.ts
@@ -19,4 +19,3 @@ export function init(): Router {
   router.get('/auth/azuread-b2c-login', getAzureAdLogin);
   return router;
 }
-

--- a/server/views/azuread-b2c-login.html
+++ b/server/views/azuread-b2c-login.html
@@ -166,11 +166,21 @@
     </div>
 
     <div class="govuk-width-container">
-      <div class="outro">
+      <p id="outroText" class="outro">
         This sign in page is for users who do not work for HMCTS.<br />
         <a id="dedicatedPage" href="#">There is a dedicated page for HMCTS employees to sign into the portal.</a>
-      </div>
+      </p>
     </div>
+    <script>
+      window.onload = function () {
+        const urlParams = new URLSearchParams(window.location.search);
+        const screenName = urlParams.get('screenName');
+
+        if (screenName !== 'loginScreen') {
+          document.getElementById('outroText').style.display = 'none';
+        }
+      };
+    </script>
 
     <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container">
@@ -205,12 +215,14 @@
     <script src="{{hostname}}/assets/javascripts/govuk-frontend-4.6.0.min.js"></script>
     <script>
       window.GOVUKFrontend.initAll();
-      document.getElementById('logonIdentifier').tabIndex = 1;
-      document.getElementById('password').tabIndex = 2;
-      document.getElementById('forgotPassword').tabIndex = 3;
-      document.getElementById('rememberMe').tabIndex = 4;
-      document.getElementById('next').tabIndex = 5;
-      document.getElementById('dedicatedPage').tabIndex = 6;
     </script>
   </body>
+  <script>
+    document.getElementById('logonIdentifier').tabIndex = 1;
+    document.getElementById('password').tabIndex = 2;
+    document.getElementById('forgotPassword').tabIndex = 3;
+    document.getElementById('rememberMe').tabIndex = 4;
+    document.getElementById('next').tabIndex = 5;
+    document.getElementById('dedicatedPage').tabIndex = 6;
+  </script>
 </html>

--- a/server/views/azuread-b2c-login.html
+++ b/server/views/azuread-b2c-login.html
@@ -165,22 +165,14 @@
       <div id="api"></div>
     </div>
 
+    {% if screen === 'loginScreen' %}
     <div class="govuk-width-container">
       <p id="outroText" class="outro">
         This sign in page is for users who do not work for HMCTS.<br />
         <a id="dedicatedPage" href="#">There is a dedicated page for HMCTS employees to sign into the portal.</a>
       </p>
     </div>
-    <script>
-      window.onload = function () {
-        const urlParams = new URLSearchParams(window.location.search);
-        const screenName = urlParams.get('screenName');
-
-        if (screenName !== 'loginScreen') {
-          document.getElementById('outroText').style.display = 'none';
-        }
-      };
-    </script>
+    {% endif %}
 
     <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container">


### PR DESCRIPTION
### Change description ###

A condition has been added which targets the outro text on the bottom of the page. If the URL contains the query parameter 'screenName=loginScreen', then the text is visible. If this parameter does not exist in the URL, then the text will not display.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
