### PR TITLE
DMP-627 New SecurityToken object for handle-oauth api, new classes an…

### DIFF
--- a/server/controllers/api.ts
+++ b/server/controllers/api.ts
@@ -13,8 +13,10 @@ function proxyMiddleware() {
     },
     logLevel: 'debug',
     onProxyReq: (proxyReq, req) => {
-      if (req.session.accessToken) {
-        proxyReq.setHeader('Authorization', `Bearer ${req.session.accessToken}`);
+      if (req.session.securityToken) {
+        if (req.session.securityToken.accessToken){
+          proxyReq.setHeader('Authorization', `Bearer ${req.session.securityToken.accessToken}`);
+        }
       }
     },
   });

--- a/server/controllers/api.ts
+++ b/server/controllers/api.ts
@@ -14,7 +14,7 @@ function proxyMiddleware() {
     logLevel: 'debug',
     onProxyReq: (proxyReq, req) => {
       if (req.session.securityToken) {
-        if (req.session.securityToken.accessToken){
+        if (req.session.securityToken.accessToken) {
           proxyReq.setHeader('Authorization', `Bearer ${req.session.securityToken.accessToken}`);
         }
       }

--- a/server/controllers/authentication.ts
+++ b/server/controllers/authentication.ts
@@ -55,10 +55,9 @@ function postAuthCallback(): (req: Request, res: Response, next: NextFunction) =
 function getLogout(): (_: Request, res: Response, next: NextFunction) => Promise<void> {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-
       let accessToken;
-      if (req.session.securityToken){
-        accessToken = req.session.securityToken.accessToken
+      if (req.session.securityToken) {
+        accessToken = req.session.securityToken.accessToken;
       }
 
       const result = await axios(EXTERNAL_USER_LOGOUT, {
@@ -97,8 +96,8 @@ function getIsAuthenticated(disableAuthentication = false): (req: Request, res: 
     // don't allow caching of this endpoint
     res.header('Cache-Control', 'no-store, must-revalidate');
     let accessToken;
-    if (req.session.securityToken){
-      accessToken = req.session.securityToken.accessToken
+    if (req.session.securityToken) {
+      accessToken = req.session.securityToken.accessToken;
     }
 
     if (accessToken || disableAuthentication) {

--- a/server/middleware/is-authenticated.ts
+++ b/server/middleware/is-authenticated.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
 export default (req: Request, res: Response, next: NextFunction): void => {
-  if (!req.session.accessToken) {
+  if (!req.session.securityToken) {
     res.redirect('/login');
   } else {
     next();

--- a/server/types/classes/securityToken.ts
+++ b/server/types/classes/securityToken.ts
@@ -1,8 +1,8 @@
-import UserState from './userState'
+import UserState from './userState';
 
 class SecurityToken {
-    userState: UserState | undefined;
-    accessToken: string = '';
+  userState: UserState | undefined;
+  accessToken: string = '';
 }
-  
+
 export = SecurityToken;

--- a/server/types/classes/securityToken.ts
+++ b/server/types/classes/securityToken.ts
@@ -1,0 +1,8 @@
+import UserState from './userState'
+
+class SecurityToken {
+    userState: UserState | undefined;
+    accessToken: string = '';
+}
+  
+export = SecurityToken;

--- a/server/types/classes/userState.ts
+++ b/server/types/classes/userState.ts
@@ -1,0 +1,13 @@
+class UserState {
+    userId: number = 0;
+    userName: string = '';
+    roles?: Role;
+}
+
+class Role {
+    roleId: number = 0;
+    roleName: string = '';
+    //Permissions excluded for now
+}
+
+export = UserState;

--- a/server/types/classes/userState.ts
+++ b/server/types/classes/userState.ts
@@ -1,13 +1,13 @@
 class UserState {
-    userId: number = 0;
-    userName: string = '';
-    roles?: Role;
+  userId: number = 0;
+  userName: string = '';
+  roles?: Role;
 }
 
 class Role {
-    roleId: number = 0;
-    roleName: string = '';
-    //Permissions excluded for now
+  roleId: number = 0;
+  roleName: string = '';
+  //Permissions excluded for now
 }
 
 export = UserState;

--- a/server/types/session.d.ts
+++ b/server/types/session.d.ts
@@ -1,4 +1,4 @@
-import SecurityToken from './classes/securityToken'
+import SecurityToken from './classes/securityToken';
 
 declare module 'express-session' {
   interface SessionData {

--- a/server/types/session.d.ts
+++ b/server/types/session.d.ts
@@ -1,6 +1,8 @@
+import SecurityToken from './classes/securityToken'
+
 declare module 'express-session' {
   interface SessionData {
-    accessToken?: string;
+    securityToken: SecurityToken | undefined;
   }
 }
 


### PR DESCRIPTION
…d updated session module

https://tools.hmcts.net/jira/browse/DMP-627

This change relates directly to DMP-627, and required amendments of existing express-session module due to the new object being returned from the handle-oauth API as part of DMP-639. Instead of a accessToken string, a securityToken object is now returned, containing accessToken and UserState object. New classes have been added to server/types/classes to accommodate updated SessionData interface. These new typescript classes reflect Karens changes as part of 639, permissions are excluded for time being.


No tests created for this change as not sure how it could be tested



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
