### PR TITLE
dmp-507 : patch : mouse cursor change on the clear search link

### DIFF
--- a/src/app/components/search/search.component.css
+++ b/src/app/components/search/search.component.css
@@ -1,0 +1,3 @@
+#clear-search {
+  cursor: pointer;
+}

--- a/src/app/components/search/search.component.css
+++ b/src/app/components/search/search.component.css
@@ -1,3 +1,1 @@
-#clear-search {
-  cursor: pointer;
-}
+

--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -23,5 +23,5 @@
 </details>
 <div class="govuk-button-group">
   <button class="govuk-button" data-module="govuk-button">Search</button>
-  <a class="govuk-link" id="clear-search" (click)="clearSearch()">Clear search</a>
+  <a class="govuk-link" (click)="clearSearch()">Clear search</a>
 </div>

--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -23,5 +23,5 @@
 </details>
 <div class="govuk-button-group">
   <button class="govuk-button" data-module="govuk-button">Search</button>
-  <a class="govuk-link" (click)="clearSearch()">Clear search</a>
+  <a class="govuk-link" id="clear-search" (click)="clearSearch()">Clear search</a>
 </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,3 +9,7 @@
     cursor: pointer;
   }
 }
+
+a.govuk-link {
+  cursor: pointer;
+}


### PR DESCRIPTION
### Change description ###

Previously, the mouse pointer didn't change to a 'pointing hand' when hovering over the 'clear search' button. It now does.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
