### PR TITLE
dmp-507 : patch : fix missing tabbed link

### DIFF
--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -152,6 +152,6 @@
   </details>
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button" data-module="govuk-button">Search</button>
-    <a class="govuk-link" (click)="clearSearch()">Clear search</a>
+    <a class="govuk-link" href="javascript:void(0)" (click)="clearSearch()">Clear search</a>
   </div>
 </form>


### PR DESCRIPTION

### Change description ###

Fixes the issue where the clear search link was being missed when the web pages elements were tabbed through.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
