### PR TITLE
Bearer Token expiry logic

### DIFF
--- a/darts-api-stub/authentication/external.js
+++ b/darts-api-stub/authentication/external.js
@@ -22,9 +22,11 @@ router.post('/handle-oauth-code', (_, res) => {
     userName: 'localdev01',
     roles: roles,
   };
+  //Token expires 2034-08-23
   const securityToken = {
     userState: userState,
-    accessToken: 'fake-jwt',
+    accessToken:
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJEYXZpZE1hbm4iLCJpYXQiOjE2OTI4NzQ5MzAsImV4cCI6MjAzOTk0MzczMCwiYXVkIjoiZGFydHMtbG9jYWwtZGV2Iiwic3ViIjoiZGFydHMtbG9jYWwtand0In0.6wJo9geKWacjA-FR67waVRsNuS6uP5X-JJRlTOpwGhI',
   };
   res.send(securityToken);
 });


### PR DESCRIPTION
This is a bug fix as part of [DMP-827](https://tools.hmcts.net/jira/browse/DMP-827) where invalid/expired tokens do not re-route to login.

Expiry logic update for bearer token, supporting functions for parsing jwt payload and expiry, stub token included with 10 year lifespan.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
