### PR TITLE
Portal - Advanced Search - Specific date picker not setting date_to

### DIFF
--- a/src/app/components/search/search.component.spec.ts
+++ b/src/app/components/search/search.component.spec.ts
@@ -54,7 +54,7 @@ describe('SearchComponent', () => {
   });
 
   describe('#assignValue', () => {
-    it('should assign the value from the specific date picker to the input box, for Angular change detection', async () => {
+    it('should assign the value from the specific date picker to the input box, for Angular change detection, date_from and date_to should match.', async () => {
       const fixture = TestBed.createComponent(SearchComponent);
       fixture.detectChanges();
 
@@ -72,8 +72,10 @@ describe('SearchComponent', () => {
       const el = specificDateInput.nativeElement;
 
       fixture.detectChanges();
-
+      component.setInputValue('23/08/2023', 'date_to');
       expect(el.value).toEqual('23/08/2023');
+      //With specific date picker, date_from and date_to should equal the same
+      expect(component.form.controls['date_to'].value).toEqual('23/08/2023');
     });
 
     it('should assign the value from the range date picker in the date_to input to the input box, for Angular change detection', async () => {

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -45,6 +45,8 @@ export class SearchComponent implements AfterViewChecked, AfterViewInit {
 
   setInputValue(value: string, control: string) {
     this.form.controls[`${control}`].patchValue(value);
+    //If specific type, set date_to to same value as date_from
+    this.dateInputType === 'specific' && control == 'date_from' && this.form.controls[`date_to`].patchValue(value);
   }
 
   getCourthouses() {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-909

Sets date_to form control when specific date picker is used. This prevents DB returning everything after date_from when date_to is null.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
