### PR TITLE
Fix whitespace on hearing screen

### DIFF
--- a/src/app/components/hearing/hearing.component.scss
+++ b/src/app/components/hearing/hearing.component.scss
@@ -1,0 +1,4 @@
+:host {
+  margin-top: -40px;
+  display: block;
+}


### PR DESCRIPTION
### Change description ###

Remove whitespace at the top of hearing screen

![image](https://github.com/hmcts/darts-portal/assets/125365979/8a37979c-3bf0-4920-913c-23217133bf12)
