### PR TITLE
Exposing user profile to angular

### DIFF
--- a/darts-api-stub/authentication/external.js
+++ b/darts-api-stub/authentication/external.js
@@ -19,7 +19,7 @@ router.post('/handle-oauth-code', (_, res) => {
   ];
   const userState = {
     userId: 123,
-    userName: 'localdev01',
+    userName: 'dev@local',
     roles: roles,
   };
 

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,4 +1,5 @@
 export * as apiController from './api';
 export * as appController from './app';
+export * as userController from './user';
 export * as authController from './auth';
 export * as authenticationController from './authentication';

--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -1,0 +1,8 @@
+import * as express from 'express';
+import { Router, Request, Response } from 'express';
+
+export function init(): Router {
+  const router = express.Router();
+  router.get('/profile', (req: Request, res: Response) => res.json(req.session.securityToken?.userState));
+  return router;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import express, { NextFunction, Request, Response } from 'express';
 import type { Router } from 'express';
-import { apiController, appController, authController, authenticationController } from './controllers';
+import { apiController, appController, authController, authenticationController, userController } from './controllers';
 import { isAuthenticated } from './middleware';
 
 export default (disableAuthentication = false): Router => {
@@ -12,6 +12,7 @@ export default (disableAuthentication = false): Router => {
 
   // authenticated routes
   router.use('/api', checkAuthenticated, apiController.init());
+  router.use('/user', checkAuthenticated, userController.init());
 
   // unauthenticated routes
   router.use('/auth', authenticationController.init(disableAuthentication));

--- a/server/types/classes/securityToken.ts
+++ b/server/types/classes/securityToken.ts
@@ -2,7 +2,7 @@ import UserState from './userState';
 
 class SecurityToken {
   userState: UserState | undefined;
-  accessToken: string = '';
+  accessToken!: string;
 }
 
 export = SecurityToken;

--- a/server/types/classes/userState.ts
+++ b/server/types/classes/userState.ts
@@ -1,18 +1,18 @@
 class UserState {
-  userId: number = 0;
-  userName: string = '';
+  userId!: number;
+  userName!: string;
   roles?: Role[];
 }
 
 class Role {
-  roleId: number = 0;
-  roleName: string = '';
+  roleId!: number;
+  roleName!: string;
   permissions?: Permissions[];
 }
 
 class Permissions {
-  permissionId: number = 0;
-  permissionName: string = '';
+  permissionId!: number;
+  permissionName!: string;
 }
 
-export = UserState;
+export default UserState;

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -114,7 +114,7 @@ export class SearchComponent implements OnInit, AfterViewChecked, OnDestroy {
     return this.isSubmitted && !!this.f[control].errors;
   }
 
-  onSubmit() {
+  async onSubmit() {
     this.isSubmitted = true;
     this.form.updateValueAndValidity();
 

--- a/src/app/services/app-config/app-config.service.ts
+++ b/src/app/services/app-config/app-config.service.ts
@@ -15,9 +15,7 @@ export class AppConfigService {
   constructor(private http: HttpBackendClient) {}
 
   async loadAppConfig(): Promise<void> {
-    console.log('loading app config');
     this.appConfig = await lastValueFrom(this.http.get<AppConfig>(CONFIG_PATH));
-    console.log('loading app config', this.appConfig);
   }
 
   getAppConfig(): AppConfig | undefined {

--- a/src/app/services/user/user.service.spec.ts
+++ b/src/app/services/user/user.service.spec.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import UserState from 'server/types/classes/userState';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let httpClientSpy: HttpClient;
+  let userService: UserService;
+  let getSpy: jest.SpyInstance<unknown>;
+
+  const testData: UserState = { userName: 'test@test.com', userId: 1, roles: [] };
+
+  beforeEach(() => {
+    httpClientSpy = {
+      get: jest.fn(),
+    } as unknown as HttpClient;
+    userService = new UserService(httpClientSpy);
+    getSpy = jest.spyOn(httpClientSpy, 'get').mockReturnValue(of(testData));
+  });
+
+  it('should be created', () => {
+    expect(userService).toBeTruthy();
+  });
+
+  it('loads user profile', async () => {
+    const userProfile = await userService.getUserProfile();
+    expect(userProfile).toEqual(testData);
+  });
+
+  it('only loads the user profile the first time', async () => {
+    await userService.getUserProfile();
+    expect(httpClientSpy.get).toHaveBeenCalledTimes(1);
+    // get the profile again
+    await userService.getUserProfile();
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/services/user/user.service.ts
+++ b/src/app/services/user/user.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { UserState } from '@darts-types/user-state';
+import { lastValueFrom } from 'rxjs';
+
+const USER_PROFILE_PATH = '/user/profile';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  private userProfile: UserState | undefined;
+
+  constructor(private http: HttpClient) {}
+
+  private async loadUserProfile(): Promise<void> {
+    this.userProfile = await lastValueFrom(this.http.get<UserState>(USER_PROFILE_PATH));
+  }
+
+  async getUserProfile(): Promise<UserState | undefined> {
+    if (!this.userProfile) {
+      await this.loadUserProfile();
+    }
+    return this.userProfile;
+  }
+}

--- a/src/app/types/user-state.ts
+++ b/src/app/types/user-state.ts
@@ -1,0 +1,16 @@
+export interface UserState {
+  userId: number;
+  userName: string;
+  roles: Role[];
+}
+
+interface Role {
+  roleId: number;
+  roleName: string;
+  permissions?: Permissions[];
+}
+
+interface Permissions {
+  permissionId: number;
+  permissionName: string;
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- via /user/profile endpoint on the node server
- `userService.getUserProfile` can be used in angular component, must be an async call

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
