### PR TITLE
Adding loading component

### DIFF
--- a/src/app/components/common/loading/loading.component.html
+++ b/src/app/components/common/loading/loading.component.html
@@ -1,0 +1,4 @@
+<div class="loading-container">
+  <div class="govuk-spinner" [ngClass]="{ small: size === 'small' }"></div>
+  <h1 class="govuk-heading-m">{{ text }}</h1>
+</div>

--- a/src/app/components/common/loading/loading.component.scss
+++ b/src/app/components/common/loading/loading.component.scss
@@ -1,0 +1,42 @@
+.loading-container {
+  text-align: center;
+  padding-top: 40px;
+
+  .govuk-spinner {
+    margin: 0 auto;
+    border: 12px solid #dee0e2;
+    border-radius: 50%;
+    border-top-color: #1d70b8;
+    width: 80px;
+    height: 80px;
+    -webkit-animation: spin 2s linear infinite;
+    animation: spin 2s linear infinite;
+
+    &.small {
+      width: 40px;
+      height: 40px;
+      border-width: 6px;
+    }
+  }
+
+  @-webkit-keyframes spin {
+    0% {
+      -webkit-transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  .govuk-heading-m {
+    padding-top: 20px;
+  }
+}

--- a/src/app/components/common/loading/loading.component.spec.ts
+++ b/src/app/components/common/loading/loading.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { LoadingComponent } from './loading.component';
+
+describe('LoadingComponent', () => {
+  let component: LoadingComponent;
+  let fixture: ComponentFixture<LoadingComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LoadingComponent],
+    });
+    fixture = TestBed.createComponent(LoadingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('shows with default text and size', () => {
+    const text = fixture.debugElement.query(By.css('.govuk-heading-m')).nativeElement.textContent;
+    const smallLoadingSpinner = fixture.debugElement.query(By.css('.small'));
+    expect(smallLoadingSpinner).toBeNull();
+    expect(text).toBe('Loading...');
+  });
+
+  it('shows custom text', () => {
+    const loadingText = 'Custom loading text';
+    component.text = loadingText;
+
+    fixture.detectChanges();
+
+    const text = fixture.debugElement.query(By.css('.govuk-heading-m')).nativeElement.textContent;
+    expect(text).toBe(loadingText);
+  });
+
+  it('shows small loading spinner', () => {
+    component.size = 'small';
+    fixture.detectChanges();
+
+    const smallLoadingSpinner = fixture.debugElement.query(By.css('.small'));
+    expect(smallLoadingSpinner).toBeTruthy();
+  });
+});

--- a/src/app/components/common/loading/loading.component.ts
+++ b/src/app/components/common/loading/loading.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { NgClass } from '@angular/common';
+
+@Component({
+  selector: 'app-loading',
+  standalone: true,
+  imports: [NgClass],
+  templateUrl: './loading.component.html',
+  styleUrls: ['./loading.component.scss'],
+})
+export class LoadingComponent {
+  @Input() text = 'Loading...';
+  @Input() size: 'small' | undefined;
+}

--- a/src/app/components/hearing/hearing.component.html
+++ b/src/app/components/hearing/hearing.component.html
@@ -58,4 +58,6 @@
   </div>
 </ng-container>
 
-<ng-template #loading>Loading...</ng-template>
+<ng-template #loading>
+  <app-loading text="Loading hearing details..."></app-loading>
+</ng-template>

--- a/src/app/components/hearing/hearing.component.ts
+++ b/src/app/components/hearing/hearing.component.ts
@@ -12,10 +12,13 @@ import { EventsAndAudioComponent } from './events-and-audio/events-and-audio.com
 import { HearingFileComponent } from './hearing-file/hearing-file.component';
 import { OrderConfirmationComponent } from './order-confirmation/order-confirmation.component';
 import { RequestPlaybackAudioComponent } from './request-playback-audio/request-playback-audio.component';
+import { LoadingComponent } from '../common/loading/loading.component';
 
 @Component({
   selector: 'app-hearing',
   standalone: true,
+  templateUrl: './hearing.component.html',
+  styleUrls: ['./hearing.component.scss'],
   imports: [
     CommonModule,
     HearingFileComponent,
@@ -24,9 +27,8 @@ import { RequestPlaybackAudioComponent } from './request-playback-audio/request-
     OrderConfirmationComponent,
     ReportingRestrictionComponent,
     RouterLink,
+    LoadingComponent,
   ],
-  templateUrl: './hearing.component.html',
-  styleUrls: ['./hearing.component.scss'],
 })
 export class HearingComponent {
   private route = inject(ActivatedRoute);


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

I know it's not in the design (yet), but I thought the "Loading..." text we display when loading hearing could do with being a bit more stylish.

<p align="center">
<img width="612" alt="Screenshot 2023-09-28 at 10 36 11" src="https://github.com/hmcts/darts-portal/assets/1334068/0beaaa75-0985-4158-a490-5e4f3ef9130d">
</p>

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
