### PR TITLE
Map hearing date responses to UTC format

### DIFF
--- a/src/app/components/audios/audios.component.ts
+++ b/src/app/components/audios/audios.component.ts
@@ -3,7 +3,7 @@ import { Component, inject } from '@angular/core';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { AudioService } from '@services/audio/audio.service';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { combineLatest, map, Observable, shareReplay, tap } from 'rxjs';
+import { combineLatest, map, Observable } from 'rxjs';
 import { CommonModule, DatePipe } from '@angular/common';
 import { UserAudioRequest } from '@darts-types/user-audio-request.interface';
 import { TableRowTemplateDirective } from 'src/app/directives/table-row-template.directive';

--- a/src/app/components/hearing/order-confirmation/order-confirmation.component.html
+++ b/src/app/components/hearing/order-confirmation/order-confirmation.component.html
@@ -16,7 +16,7 @@
     <p class="govuk-body">{{ case.defendants }}</p>
     <h2 class="govuk-heading-m">Audio details</h2>
     <h1 class="govuk-heading-s">Hearing date</h1>
-    <h1 class="govuk-body">{{ hearing?.date }}</h1>
+    <h1 class="govuk-body">{{ hearing?.date | date: 'dd/MM/yyyy' }}</h1>
     <ng-container *ngIf="audioRequest">
       <h3 class="govuk-heading-s">Start Time</h3>
       <p class="govuk-body">{{ audioRequest.start_time | date: 'HH:mm:ss' }}</p>

--- a/src/app/components/hearing/order-confirmation/order-confirmation.component.html
+++ b/src/app/components/hearing/order-confirmation/order-confirmation.component.html
@@ -16,7 +16,7 @@
     <p class="govuk-body">{{ case.defendants }}</p>
     <h2 class="govuk-heading-m">Audio details</h2>
     <h1 class="govuk-heading-s">Hearing date</h1>
-    <h1 class="govuk-body">{{ hearing?.date | date: 'dd/MM/yyyy' }}</h1>
+    <h1 class="govuk-body">{{ hearing?.date | date: 'd MMM y' }}</h1>
     <ng-container *ngIf="audioRequest">
       <h3 class="govuk-heading-s">Start Time</h3>
       <p class="govuk-body">{{ audioRequest.start_time | date: 'HH:mm:ss' }}</p>

--- a/src/app/components/hearing/request-playback-audio/request-playback-audio.component.ts
+++ b/src/app/components/hearing/request-playback-audio/request-playback-audio.component.ts
@@ -147,11 +147,11 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
     const endTimeMinutes = this.audioRequestForm.get('endTime.minutes')?.value;
     const endTimeSeconds = this.audioRequestForm.get('endTime.seconds')?.value;
 
-    const startDateTime = DateTime.fromISO(
-      `${this.hearing.date}T${startTimeHours}:${startTimeMinutes}:${startTimeSeconds}`
-    );
+    const hearingDate = this.hearing.date.replace('Z', '');
 
-    const endDateTime = DateTime.fromISO(`${this.hearing.date}T${endTimeHours}:${endTimeMinutes}:${endTimeSeconds}`);
+    const startDateTime = DateTime.fromISO(`${hearingDate}T${startTimeHours}:${startTimeMinutes}:${startTimeSeconds}`);
+
+    const endDateTime = DateTime.fromISO(`${hearingDate}T${endTimeHours}:${endTimeMinutes}:${endTimeSeconds}`);
 
     if (!startDateTime.isValid || !endDateTime.isValid || this.audioRequestForm.get('requestType')?.invalid) return;
 

--- a/src/app/services/audio/audio.service.spec.ts
+++ b/src/app/services/audio/audio.service.spec.ts
@@ -201,7 +201,7 @@ describe('AudioService', () => {
 
         req.flush(mockAudios);
 
-        expect(audios).toEqual(mockAudios);
+        expect(audios).toEqual(mockAudios.map((ar) => ({ ...ar, hearing_date: ar.hearing_date + 'Z' })));
       });
     });
 

--- a/src/app/services/audio/audio.service.ts
+++ b/src/app/services/audio/audio.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { UserAudioRequest } from '@darts-types/user-audio-request.interface';
 import { UserService } from '@services/user/user.service';
-import { BehaviorSubject, Observable, combineLatest, switchMap, tap, timer } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, switchMap, tap, timer, map } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -46,10 +46,12 @@ export class AudioService {
   }
 
   getAudioRequestsForUser(userId: number, expired: boolean): Observable<UserAudioRequest[]> {
-    return this.http.get<UserAudioRequest[]>(`api/audio-requests`, {
-      headers: { user_id: userId.toString() },
-      params: { expired },
-    });
+    return this.http
+      .get<UserAudioRequest[]>(`api/audio-requests`, {
+        headers: { user_id: userId.toString() },
+        params: { expired },
+      })
+      .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'Z' }))));
   }
 
   updateUnread(audioRequests: UserAudioRequest[]) {

--- a/src/app/services/case/case.service.spec.ts
+++ b/src/app/services/case/case.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { Case, CaseFile, Courthouse, Hearing, SearchFormValues } from '@darts-types/index';
 import { ADVANCED_SEARCH_CASE_PATH, CaseService, GET_CASE_PATH, GET_COURTHOUSES_PATH } from './case.service';
 
@@ -104,7 +104,7 @@ describe('CaseService', () => {
 
     req.flush(mockHearings);
 
-    expect(hearingsResponse).toEqual(mockHearings);
+    expect(hearingsResponse).toEqual(mockHearings.map((h) => ({ ...h, date: h.date + 'Z' })));
   });
 
   it('#searchCases', () => {

--- a/src/app/services/case/case.service.ts
+++ b/src/app/services/case/case.service.ts
@@ -33,7 +33,9 @@ export class CaseService {
   }
 
   getCaseHearings(caseId: number): Observable<Hearing[]> {
-    return this.http.get<Hearing[]>(`${GET_CASE_PATH}/${caseId}/hearings`);
+    return this.http
+      .get<Hearing[]>(`${GET_CASE_PATH}/${caseId}/hearings`)
+      .pipe(map((hearings) => hearings.map((h) => ({ ...h, date: h.date + 'Z' }))));
   }
 
   searchCases(searchForm: SearchFormValues): Observable<Case[]> {


### PR DESCRIPTION
Hearing dates are displaying a day behind on the the portal. This is due to date format 'yyyy-mm-dd' on hearing dates being returned from the API.

This is inconsistent with other date / time responses. The fix is to append 'Z' to dates so the Datepipe in Angular understands this date to be UTC and not BST and therefore not subtract an hour from the day before.
