### PR TITLE
Setting app-insights cloud role name

### DIFF
--- a/src/app/services/app-insights/app-insights.service.ts
+++ b/src/app/services/app-insights/app-insights.service.ts
@@ -1,10 +1,11 @@
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { ApplicationInsights, ITelemetryItem } from '@microsoft/applicationinsights-web';
 import { Injectable } from '@angular/core';
 import { AppConfigService } from '@services/app-config/app-config.service';
 
 @Injectable()
 export class AppInsightsService {
   appInsights: ApplicationInsights;
+  private readonly cloudRoleName = 'DARTS portal';
 
   constructor(private readonly appConfigService: AppConfigService) {
     this.appInsights = new ApplicationInsights({
@@ -13,6 +14,18 @@ export class AppInsightsService {
         enableAutoRouteTracking: true, // option to log all route changes
       },
     });
+    const telemetryInitializer = (envelope: ITelemetryItem) => {
+      if (envelope.tags && envelope.tags['ai.cloud.role']) {
+        envelope.tags['ai.cloud.role'] = this.cloudRoleName;
+      } else {
+        envelope.tags = [
+          {
+            'ai.cloud.role': this.cloudRoleName,
+          },
+        ];
+      }
+    };
+    this.appInsights.addTelemetryInitializer(telemetryInitializer);
     this.appInsights.loadAppInsights();
   }
 


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Setting up "Cloud role name" for application insights.

![Screenshot 2023-10-12 at 15 25 11](https://github.com/hmcts/darts-portal/assets/1334068/6fee6100-ad40-4614-99ee-186b0e37b5be)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
