### PR TITLE
pa11y updates to show only new issues, flag to ignore known

### DIFF
--- a/pa11y/pa11y.ts
+++ b/pa11y/pa11y.ts
@@ -13,6 +13,8 @@ export const pathsToTest = [
   '/page-not-found',
 ];
 
+//Flag to IGNORE 'known' issues for now, also hides them from logs
+const ignoreKnownIssues = true;
 //Contains 'code' of known issues to ignore when exiting process
 const knownIssues = ['color-contrast'];
 //pa11y will fail if errors appear that aren't known
@@ -20,6 +22,8 @@ let error = false;
 
 async function runPa11y() {
   try {
+    console.log('Ignore known issues set to ', ignoreKnownIssues);
+
     const results = await Promise.all(
       pathsToTest.map((path) =>
         pa11y(`${testUrl}${path}`, {
@@ -28,24 +32,50 @@ async function runPa11y() {
       )
     );
 
+    let newIssueCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let issuesArr: any = [];
+
     results.forEach((result) => {
       console.log(`URL: ${result.pageUrl}`);
-      console.log(`Number of issues: ${result.issues.length}`);
       if (result.issues.length > 0) {
-        console.log(result.issues);
-        // If issues contains an issue that isn't known
-        if (result.issues.some((r) => !knownIssues.includes(r.code))) {
-          console.log('Unknown issue(s) found for ', result.pageUrl);
-          error = true;
+        for (const x in result.issues) {
+          const issue = result.issues[x];
+          if (knownIssues.indexOf(issue.code) == -1) {
+            //Issue is unknown
+            newIssueCount = newIssueCount + 1;
+            issuesArr.push(result.issues[x]);
+            error = true;
+          } else if (!ignoreKnownIssues) {
+            //Adds known issues
+            issuesArr.push(result.issues[x]);
+          }
         }
       }
+      console.log(`Number of total issues (including known): ${result.issues.length}`);
+      console.log('Number of NEW issues: ', newIssueCount);
+
+      if (ignoreKnownIssues) {
+        console.log('Ignoring known issues');
+      } else if (!ignoreKnownIssues && !error) {
+        console.log('Showing known issues');
+        console.log(issuesArr);
+      }
+      if (issuesArr.length > 0 && ignoreKnownIssues) {
+        console.log(issuesArr);
+        console.log('Please fix the above');
+      }
+
       console.log('--');
+      //Clear for next page
+      newIssueCount = 0;
+      issuesArr = [];
     });
 
     const aggregatedResultCount = results.reduce((aggregated, r) => aggregated + r.issues.length, 0);
     console.log('Total number of issues:', aggregatedResultCount);
     if (error) {
-      console.log('Unknown issue(s) have been detected');
+      console.log('Unknown issue(s) have been detected, fix above');
       process.exit(aggregatedResultCount);
     } else {
       process.exit(0);

--- a/pa11y/pa11y.ts
+++ b/pa11y/pa11y.ts
@@ -39,18 +39,17 @@ async function runPa11y() {
     results.forEach((result) => {
       console.log(`URL: ${result.pageUrl}`);
       if (result.issues.length > 0) {
-        for (const x in result.issues) {
-          const issue = result.issues[x];
+        result.issues.forEach((issue) => {
           if (knownIssues.indexOf(issue.code) == -1) {
             //Issue is unknown
-            newIssueCount = newIssueCount + 1;
-            issuesArr.push(result.issues[x]);
+            newIssueCount = newIssueCount++;
+            issuesArr.push(issue);
             error = true;
           } else if (!ignoreKnownIssues) {
             //Adds known issues
-            issuesArr.push(result.issues[x]);
+            issuesArr.push(issue);
           }
-        }
+        });
       }
       console.log(`Number of total issues (including known): ${result.issues.length}`);
       console.log('Number of NEW issues: ', newIssueCount);

--- a/pa11y/pa11y.ts
+++ b/pa11y/pa11y.ts
@@ -32,17 +32,16 @@ async function runPa11y() {
       )
     );
 
-    let newIssueCount = 0;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let issuesArr: any = [];
-
     results.forEach((result) => {
+      let newIssueCount = 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const issuesArr: any = [];
       console.log(`URL: ${result.pageUrl}`);
       if (result.issues.length > 0) {
         result.issues.forEach((issue) => {
           if (knownIssues.indexOf(issue.code) == -1) {
             //Issue is unknown
-            newIssueCount = newIssueCount++;
+            newIssueCount++;
             issuesArr.push(issue);
             error = true;
           } else if (!ignoreKnownIssues) {
@@ -66,9 +65,6 @@ async function runPa11y() {
       }
 
       console.log('--');
-      //Clear for next page
-      newIssueCount = 0;
-      issuesArr = [];
     });
 
     const aggregatedResultCount = results.reduce((aggregated, r) => aggregated + r.issues.length, 0);


### PR DESCRIPTION
This change hides known issues flagged in pa11y by default. Log output changed to show count of unknown issues, and also show detail of these issues.

There is still problem accessing pages which require UserState when pa11y runs in non auth mode, to be covered in separate ticket.

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
