### PR TITLE
DMP:1277: Fix date bug for Safari and Firefox

### DIFF
--- a/src/app/components/hearing/request-playback-audio/request-playback-audio.component.ts
+++ b/src/app/components/hearing/request-playback-audio/request-playback-audio.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -8,14 +9,13 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { TimeInputComponent } from './time-input/time-input.component';
 import { AudioRequest, ErrorSummaryEntry, FieldErrors, Hearing } from '@darts-types/index';
-import { timeGroupValidator } from '@validators/time-group.validator';
 import { UserState } from '@darts-types/user-state';
 import { UserService } from '@services/user/user.service';
+import { timeGroupValidator } from '@validators/time-group.validator';
 import { DateTime } from 'luxon';
+import { TimeInputComponent } from './time-input/time-input.component';
 
 const fieldErrors: FieldErrors = {
   startTime: {
@@ -147,7 +147,7 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
     const endTimeMinutes = this.audioRequestForm.get('endTime.minutes')?.value;
     const endTimeSeconds = this.audioRequestForm.get('endTime.seconds')?.value;
 
-    const hearingDate = this.hearing.date.replace('Z', '');
+    const hearingDate = this.hearing.date.replace('T00:00:00Z', '');
 
     const startDateTime = DateTime.fromISO(`${hearingDate}T${startTimeHours}:${startTimeMinutes}:${startTimeSeconds}`);
 

--- a/src/app/services/audio-request/audio-request.service.spec.ts
+++ b/src/app/services/audio-request/audio-request.service.spec.ts
@@ -214,7 +214,7 @@ describe('AudioService', () => {
 
         req.flush(mockAudios);
 
-        expect(audios).toEqual(mockAudios.map((ar) => ({ ...ar, hearing_date: ar.hearing_date + 'Z' })));
+        expect(audios).toEqual(mockAudios.map((ar) => ({ ...ar, hearing_date: ar.hearing_date + 'T00:00:00Z' })));
       });
     });
 

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -53,7 +53,7 @@ export class AudioRequestService {
         headers: { user_id: userId.toString() },
         params: { expired },
       })
-      .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'Z' }))));
+      .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'T00:00:00Z' }))));
   }
 
   deleteAudioRequests(mediaRequestId: number): Observable<HttpResponse<Response>> {

--- a/src/app/services/case/case.service.spec.ts
+++ b/src/app/services/case/case.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Case, CaseFile, Courthouse, Hearing, SearchFormValues } from '@darts-types/index';
 import { ADVANCED_SEARCH_CASE_PATH, CaseService, GET_CASE_PATH, GET_COURTHOUSES_PATH } from './case.service';
@@ -104,7 +104,7 @@ describe('CaseService', () => {
 
     req.flush(mockHearings);
 
-    expect(hearingsResponse).toEqual(mockHearings.map((h) => ({ ...h, date: h.date + 'Z' })));
+    expect(hearingsResponse).toEqual(mockHearings.map((h) => ({ ...h, date: h.date + 'T00:00:00Z' })));
   });
 
   it('#searchCases', () => {

--- a/src/app/services/case/case.service.ts
+++ b/src/app/services/case/case.service.ts
@@ -1,8 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Case, Courthouse, Hearing, SearchFormValues } from '@darts-types/index';
-import { of } from 'rxjs';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, map, shareReplay } from 'rxjs/operators';
 
 export const GET_COURTHOUSES_PATH = '/api/courthouses';
@@ -35,7 +34,7 @@ export class CaseService {
   getCaseHearings(caseId: number): Observable<Hearing[]> {
     return this.http
       .get<Hearing[]>(`${GET_CASE_PATH}/${caseId}/hearings`)
-      .pipe(map((hearings) => hearings.map((h) => ({ ...h, date: h.date + 'Z' }))));
+      .pipe(map((hearings) => hearings.map((h) => ({ ...h, date: h.date + 'T00:00:00Z' }))));
   }
   searchCases(searchForm: SearchFormValues): Observable<Case[]> {
     // Save search form values


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-1277

### Change description ###

Turns out that appending just 'Z' to dates to get a UTC date only works in Chrome.
The fix is to append the full 'T00:00:00Z' for the time portion of the DateTime.