### PR TITLE
Adding option to allow auth bootstrap

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -6,6 +6,7 @@
     "url": "DARTS_API_URL"
   },
   "authentication": {
-    "azureAdB2cOriginHost": "DARTS_AZUREAD_B2C_ORIGIN_HOST"
+    "azureAdB2cOriginHost": "DARTS_AZUREAD_B2C_ORIGIN_HOST",
+    "allowAuthBootstrap": "DARTS_ALLOW_AUTH_BOOTSTRAP"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -6,7 +6,8 @@
     "url": "http://localhost:4550"
   },
   "authentication": {
-    "azureAdB2cOriginHost": "*"
+    "azureAdB2cOriginHost": "*",
+    "allowAuthBootstrap": "false"
   },
   "secrets": {
     "darts": {

--- a/server/utils/base64.ts
+++ b/server/utils/base64.ts
@@ -1,0 +1,7 @@
+export function encode<T>(dataToEncode: T): string {
+  return Buffer.from(JSON.stringify(dataToEncode)).toString('base64');
+}
+
+export function decodeObject<T>(base64string: string): T {
+  return JSON.parse(Buffer.from(base64string, 'base64').toString());
+}


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

- this means passing a base64 encoded SecurityToken object to a special endpoint
- this endpoint adds it to the session allowing authentication without going through the AD flow
- the access token is still checked on the API so it must be valid
- this can be used to test when authentication through the AD is not possible, possibly due to callback URLs

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
