### PR TITLE
DMP-1323 Generic internal server error page, unit tests, functional tests

### DIFF
--- a/cypress/e2e/functional/case-search-spec.cy.js
+++ b/cypress/e2e/functional/case-search-spec.cy.js
@@ -202,7 +202,6 @@ describe('Case search', () => {
     cy.get('button').contains('Search').click();
     cy.get('h1').should('contain', 'Internal Server Error');
     cy.get('.govuk-body').should('contain', 'There was an error during operation.');
-    cy.get('.govuk-body').should('contain', 'There was an error during operation.');
     cy.get('.moj-primary-navigation').should('not.exist');
   });
 });

--- a/cypress/e2e/functional/case-search-spec.cy.js
+++ b/cypress/e2e/functional/case-search-spec.cy.js
@@ -194,14 +194,4 @@ describe('Case search', () => {
 
     cy.get('#search-results').should('contain', '1 result');
   });
-
-  it('should route to Error page on 500 response', () => {
-    cy.contains('Search').click();
-    cy.get('h1').should('contain', 'Search for a case');
-    cy.get('#case_number').type('INTERNAL_SERVER_ERROR');
-    cy.get('button').contains('Search').click();
-    cy.get('h1').should('contain', 'Internal Server Error');
-    cy.get('.govuk-body').should('contain', 'There was an error during operation.');
-    cy.get('.moj-primary-navigation').should('not.exist');
-  });
 });

--- a/cypress/e2e/functional/case-search-spec.cy.js
+++ b/cypress/e2e/functional/case-search-spec.cy.js
@@ -1,5 +1,5 @@
-import './commands';
 import { DateTime } from 'luxon';
+import './commands';
 
 const TOMORROW = DateTime.now().plus({ days: 1 }).startOf('day').toFormat('dd/MM/yyyy');
 
@@ -193,5 +193,16 @@ describe('Case search', () => {
     cy.get('#keywords').should('have.value', 'Daffy duck');
 
     cy.get('#search-results').should('contain', '1 result');
+  });
+
+  it('should route to Error page on 500 response', () => {
+    cy.contains('Search').click();
+    cy.get('h1').should('contain', 'Search for a case');
+    cy.get('#case_number').type('INTERNAL_SERVER_ERROR');
+    cy.get('button').contains('Search').click();
+    cy.get('h1').should('contain', 'Internal Server Error');
+    cy.get('.govuk-body').should('contain', 'There was an error during operation.');
+    cy.get('.govuk-body').should('contain', 'There was an error during operation.');
+    cy.get('.moj-primary-navigation').should('not.exist');
   });
 });

--- a/cypress/e2e/functional/error-spec.cy.js
+++ b/cypress/e2e/functional/error-spec.cy.js
@@ -1,0 +1,39 @@
+import './commands';
+
+describe('Error page handling', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should show in-component error for INTERNAL_SERVER_ERROR search', () => {
+    cy.contains('Search').click();
+    cy.get('h1').should('contain', 'Search for a case');
+    cy.get('#case_number').type('INTERNAL_SERVER_ERROR');
+    cy.get('button').contains('Search').click();
+    cy.get('h2').should('contain', 'An error has occurred');
+    cy.get('.govuk-body').should('contain', 'Try again or contact Crown IT Support if the problem persists');
+  });
+
+  it('should show full-page error for 500 responses', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/audio-requests*',
+      },
+      {
+        statusCode: 500,
+      }
+    ).as('getAudioRequests');
+
+    cy.visit('/audios');
+
+    cy.wait('@getAudioRequests').then((interception) => {
+      const response = interception.response;
+
+      expect(response.statusCode).to.equal(500);
+      cy.get('h1').should('contain', 'There is a problem with the service');
+      cy.get('p').should('contain', 'Try again or contact Crown IT Support if the problem persists');
+      cy.get('.moj-primary-navigation').should('not.exist');
+    });
+  });
+});

--- a/darts-api-stub/cases/case.js
+++ b/darts-api-stub/cases/case.js
@@ -466,6 +466,9 @@ router.get('/search', (req, res) => {
       );
   }
   switch (req.query.case_number) {
+    case 'INTERNAL_SERVER_ERROR':
+      res.sendStatus(500);
+      break;
     case 'TOO_MANY_RESULTS':
       const resBody100 = {
         type: 'CASE_100',

--- a/pa11y/pa11y.ts
+++ b/pa11y/pa11y.ts
@@ -2,13 +2,21 @@ import pa11y from 'pa11y';
 
 import { testUrl } from './config';
 
-export const pathsToTest = ['/', '/search', '/transcriptions', '/case/1', '/case/1/hearing/1', '/page-not-found'];
+export const pathsToTest = [
+  '/search',
+  '/transcriptions',
+  '/case/1',
+  '/case/1/hearing/1',
+  '/page-not-found',
+  '/internal-error',
+];
 //List of paths that depend on UserState to load
 export const pathsToTestUserState = ['/audios'];
 
 //Neccessary to login to application so that we can test pages that require UserState (e.g. Your Audios)
 const loginActions = [
   `navigate to ${testUrl}/login`,
+  'wait for element #user-type-2 to be visible',
   'check field #user-type-2',
   'click element .govuk-button',
   'click element #login',
@@ -49,7 +57,6 @@ async function pa11yPagesUserState() {
         })
       )
     );
-
     results.forEach((result) => {
       console.log(`URL: ${result.pageUrl}`);
       result.issues.forEach((issue) => {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { inject } from '@angular/core';
 import { Routes } from '@angular/router';
 import { NotFoundComponent } from '@common/not-found/not-found.component';
+import { InternalErrorComponent } from '@components/error/internal-server/internal-error.component';
 import { UserService } from '@services/user/user.service';
 import { authGuard } from './auth/auth.guard';
 import { LoginComponent } from './components/login/login.component';
@@ -9,6 +10,7 @@ const openRoutes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: '', redirectTo: '/search', pathMatch: 'full' },
   { path: 'page-not-found', component: NotFoundComponent },
+  { path: 'internal-error', component: InternalErrorComponent },
   { path: '**', redirectTo: '/page-not-found' },
 ];
 const protectedRoutes: Routes = [

--- a/src/app/components/error/internal-server/internal-error.component.html
+++ b/src/app/components/error/internal-server/internal-error.component.html
@@ -1,15 +1,36 @@
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Internal Server Error</h1>
-        <!-- We should add unique identification for support requests later on -->
-        <p class="govuk-body">There was an error during operation.</p>
-        <p class="govuk-body">
-          Please try again later,
-          <a href="#" class="govuk-link">or contact the support team.</a>
-        </p>
+<ng-container *ngIf="error$ | async as error; else defaultContent">
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 *ngIf="!error.display || error.display === 'PAGE'" class="govuk-heading-l">
+            There is a problem with the service
+          </h1>
+          <h2 *ngIf="error.display === 'COMPONENT'" class="govuk-heading-l">An error has occurred.</h2>
+          <!-- We should add unique identification for support requests later on -->
+          <p class="govuk-body">
+            Try again or
+            <a href="mailto:crownITsupport@justice.gov.uk" class="govuk-link">contact Crown IT Support</a> if the
+            problem persists
+          </p>
+        </div>
       </div>
-    </div>
-  </main>
-</div>
+    </main>
+  </div>
+</ng-container>
+<ng-template #defaultContent>
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">There is a problem with the service</h1>
+          <p class="govuk-body">
+            Try again or
+            <a href="mailto:crownITsupport@justice.gov.uk" class="govuk-link">contact Crown IT Support</a> if the
+            problem persists
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+</ng-template>

--- a/src/app/components/error/internal-server/internal-error.component.html
+++ b/src/app/components/error/internal-server/internal-error.component.html
@@ -1,0 +1,15 @@
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Internal Server Error</h1>
+        <!-- We should add unique identification for support requests later on -->
+        <p class="govuk-body">There was an error during operation.</p>
+        <p class="govuk-body">
+          Please try again later,
+          <a href="#" class="govuk-link">or contact the support team.</a>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/src/app/components/error/internal-server/internal-error.component.spec.ts
+++ b/src/app/components/error/internal-server/internal-error.component.spec.ts
@@ -1,0 +1,20 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InternalErrorComponent } from './internal-error.component';
+
+describe('ErrorComponent', () => {
+  let component: InternalErrorComponent;
+  let fixture: ComponentFixture<InternalErrorComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [InternalErrorComponent],
+    });
+    fixture = TestBed.createComponent(InternalErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/error/internal-server/internal-error.component.ts
+++ b/src/app/components/error/internal-server/internal-error.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { HeaderService } from '@services/header/header.service';
+
+@Component({
+  selector: 'app-internal-error',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './internal-error.component.html',
+  styleUrls: ['./internal-error.component.scss'],
+})
+export class InternalErrorComponent implements OnInit {
+  headerService = inject(HeaderService);
+
+  ngOnInit(): void {
+    this.headerService.hideNavigation();
+  }
+}

--- a/src/app/components/error/internal-server/internal-error.component.ts
+++ b/src/app/components/error/internal-server/internal-error.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, inject } from '@angular/core';
-import { HeaderService } from '@services/header/header.service';
+import { Component, inject } from '@angular/core';
+import { ErrorMessageService } from '@services/error/error-message.service';
 
 @Component({
   selector: 'app-internal-error',
@@ -9,10 +9,7 @@ import { HeaderService } from '@services/header/header.service';
   templateUrl: './internal-error.component.html',
   styleUrls: ['./internal-error.component.scss'],
 })
-export class InternalErrorComponent implements OnInit {
-  headerService = inject(HeaderService);
-
-  ngOnInit(): void {
-    this.headerService.hideNavigation();
-  }
+export class InternalErrorComponent {
+  errorMsgService = inject(ErrorMessageService);
+  error$ = this.errorMsgService.errorMessage$;
 }

--- a/src/app/components/hearing/events-and-audio/events-and-audio.component.ts
+++ b/src/app/components/hearing/events-and-audio/events-and-audio.component.ts
@@ -1,22 +1,22 @@
-import { DataTableComponent } from '@common/data-table/data-table.component';
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
-  OnInit,
+  EventEmitter,
+  Input,
   OnChanges,
   OnDestroy,
-  Input,
+  OnInit,
   Output,
-  EventEmitter,
-  ChangeDetectionStrategy,
 } from '@angular/core';
-import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { AudioPlayerComponent } from '@common/audio-player/audio-player.component';
+import { DataTableComponent } from '@common/data-table/data-table.component';
 import { HearingEventTypeEnum } from '@darts-types/enums';
-import { DateTime } from 'luxon';
-import { HearingAudio, AudioEventRow, HearingEvent, DatatableColumn } from '@darts-types/index';
-import { Subscription } from 'rxjs';
+import { AudioEventRow, DatatableColumn, HearingAudio, HearingEvent } from '@darts-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { DateTime } from 'luxon';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-events-and-audio',

--- a/src/app/components/search/search-error/search-error.component.html
+++ b/src/app/components/search/search-error/search-error.component.html
@@ -1,30 +1,35 @@
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
 
-<div [ngSwitch]="error">
-  <div *ngSwitchCase="'CASE_100'">
-    <h2 class="govuk-heading-m">There are more than 500 results</h2>
-    <p class="govuk-body">Refine your search by:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>adding more information to your search</li>
-      <li>using filters to restrict the number of results</li>
-    </ul>
-  </div>
+<ng-container *ngIf="error">
+  <ng-container [ngSwitch]="error.type">
+    <div *ngSwitchCase="'CASE_100'">
+      <h2 class="govuk-heading-m">There are more than 500 results</h2>
+      <p class="govuk-body">Refine your search by:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>adding more information to your search</li>
+        <li>using filters to restrict the number of results</li>
+      </ul>
+    </div>
 
-  <div *ngSwitchCase="'CASE_101'">
-    <h2 class="govuk-heading-m">No search results</h2>
-    <p class="govuk-body">You need to enter some search terms and try again</p>
-  </div>
+    <div *ngSwitchCase="'CASE_101'">
+      <h2 class="govuk-heading-m">No search results</h2>
+      <p class="govuk-body">You need to enter some search terms and try again</p>
+    </div>
 
-  <div *ngSwitchCase="'CASE_102'">
-    <h2 class="govuk-heading-m">There are more than 500 results</h2>
-    <p class="govuk-body">Refine your search by:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>adding more information to your search</li>
-      <li>using filters to restrict the number of results</li>
-    </ul>
-  </div>
+    <div *ngSwitchCase="'CASE_102'">
+      <h2 class="govuk-heading-m">There are more than 500 results</h2>
+      <p class="govuk-body">Refine your search by:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>adding more information to your search</li>
+        <li>using filters to restrict the number of results</li>
+      </ul>
+    </div>
+    <div *ngSwitchDefault>
+      <h2 *ngIf="error.status !== 500" class="govuk-heading-m">An error has occurred. Please try again later.</h2>
+    </div>
+  </ng-container>
 
-  <div *ngSwitchDefault>
-    <h2 class="govuk-heading-m">An error has occurred. Please try again later.</h2>
-  </div>
-</div>
+  <ng-container *ngIf="error.status === 500">
+    <app-internal-error></app-internal-error>
+  </ng-container>
+</ng-container>

--- a/src/app/components/search/search-error/search-error.component.ts
+++ b/src/app/components/search/search-error/search-error.component.ts
@@ -1,13 +1,30 @@
-import { Component, Input } from '@angular/core';
-import { NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
+import { NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
+import { AfterViewInit, Component, Input, NgZone, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { InternalErrorComponent } from '@components/error/internal-server/internal-error.component';
+import { ErrorMessage } from '@darts-types/error-message.interface';
+import { HeaderService } from '@services/header/header.service';
 
 @Component({
   selector: 'app-search-error',
   standalone: true,
-  imports: [NgSwitchCase, NgSwitchDefault, NgSwitch],
+  imports: [NgSwitchCase, NgSwitchDefault, NgSwitch, InternalErrorComponent, NgIf],
   templateUrl: './search-error.component.html',
   styleUrls: ['./search-error.component.scss'],
 })
-export class SearchErrorComponent {
-  @Input() error: string | null = '';
+export class SearchErrorComponent implements AfterViewInit {
+  @Input() error!: ErrorMessage | null;
+
+  headerService = inject(HeaderService);
+  router = inject(Router);
+  private zone = inject(NgZone);
+
+  ngAfterViewInit(): void {
+    if (this.error?.display === 'PAGE' && this.error.status === 500) {
+      this.zone.run(() => {
+        this.router.navigateByUrl('internal-error');
+      });
+      setTimeout(() => this.headerService.hideNavigation(), 0);
+    }
+  }
 }

--- a/src/app/interceptors/error/error.interceptor.spec.ts
+++ b/src/app/interceptors/error/error.interceptor.spec.ts
@@ -1,6 +1,7 @@
-import { HttpErrorResponse, HttpRequest, HttpHandler } from '@angular/common/http';
+import { HttpErrorResponse, HttpHandler, HttpRequest } from '@angular/common/http';
 import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { ErrorMessageService } from '@services/error/error-message.service';
 import { throwError } from 'rxjs';
 import { ErrorInterceptor } from './error.interceptor';
 
@@ -12,6 +13,7 @@ class MockWindow {
 
 describe('ErrorInterceptor', () => {
   let interceptor: ErrorInterceptor;
+  let errorMsgService: ErrorMessageService;
   let errorHandler: ErrorHandler;
   let mockWindow: MockWindow;
 
@@ -21,11 +23,13 @@ describe('ErrorInterceptor', () => {
       providers: [
         ErrorInterceptor,
         { provide: ErrorHandler, useValue: { handleError: jest.fn() } },
+        { provide: ErrorMessageService, useValue: { handleErrorMessage: jest.fn() } },
         { provide: 'Window', useValue: mockWindow },
       ],
     });
     interceptor = TestBed.inject(ErrorInterceptor);
     errorHandler = TestBed.inject(ErrorHandler);
+    errorMsgService = TestBed.inject(ErrorMessageService);
   });
 
   it('should be created', () => {
@@ -42,28 +46,8 @@ describe('ErrorInterceptor', () => {
     interceptor.intercept(request, next).subscribe({
       error: (error) => {
         expect(error).toBe(errorResponse);
-        console.log(mockWindow.location.href);
         expect(mockWindow.location.href).toEqual('/login');
         expect(false);
-        done();
-      },
-    });
-  });
-
-  it('should not handle non-401 errors', (done) => {
-    const errorResponse = new HttpErrorResponse({ status: 500 });
-    const request = new HttpRequest('GET', '/test');
-    const next: HttpHandler = {
-      handle: () => throwError(() => errorResponse),
-    };
-    const handleErrorSpy = jest.spyOn(errorHandler, 'handleError');
-
-    interceptor.intercept(request, next).subscribe({
-      error: (error) => {
-        expect(error).toBe(errorResponse);
-        console.log(mockWindow.location.href);
-        expect(mockWindow.location.href).toBe('');
-        expect(handleErrorSpy).toHaveBeenCalledWith(error);
         done();
       },
     });

--- a/src/app/interceptors/error/error.interceptor.ts
+++ b/src/app/interceptors/error/error.interceptor.ts
@@ -1,11 +1,13 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { ErrorHandler, Inject, Injectable } from '@angular/core';
+import { ErrorMessageService } from '@services/error/error-message.service';
 import { Observable, catchError, throwError } from 'rxjs';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
   constructor(
     private errorHandlerService: ErrorHandler,
+    private errorMessageService: ErrorMessageService,
     @Inject('Window') private window: Window
   ) {}
 
@@ -16,6 +18,7 @@ export class ErrorInterceptor implements HttpInterceptor {
           console.log('Unauthorized access error: redirecting to login');
           this.window.location.href = '/login';
         }
+        this.errorMessageService.handleErrorMessage(error);
         this.errorHandlerService.handleError(error);
         return throwError(() => error);
       })

--- a/src/app/interceptors/error/error.interceptor.ts
+++ b/src/app/interceptors/error/error.interceptor.ts
@@ -1,6 +1,6 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { ErrorHandler, Inject, Injectable } from '@angular/core';
-import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
-import { catchError, Observable, throwError } from 'rxjs';
+import { Observable, catchError, throwError } from 'rxjs';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {

--- a/src/app/services/audio-request/audio-request.service.spec.ts
+++ b/src/app/services/audio-request/audio-request.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed, discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { UserAudioRequest } from '@darts-types/user-audio-request.interface';
 import { UserState } from '@darts-types/user-state';
 import { UserService } from '@services/user/user.service';
@@ -254,9 +254,8 @@ describe('AudioService', () => {
   });
 
   describe('constructor', () => {
-    it('audioRequests$ subscribe should call getAudioRequestsForUser and update unread count', fakeAsync(() => {
+    it('audioRequests$ subscribe should call getAudioRequestsForUser', fakeAsync(() => {
       const audioSpy = jest.spyOn(service, 'getAudioRequestsForUser');
-      const unreadSpy = jest.spyOn(service, 'updateUnread');
 
       service.audioRequests$.subscribe();
 

--- a/src/app/services/error/error-handler.service.spec.ts
+++ b/src/app/services/error/error-handler.service.spec.ts
@@ -1,14 +1,11 @@
-import { HttpErrorResponse } from '@angular/common/http';
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { ErrorHandlerService } from './error-handler.service';
 
 describe('ErrorHandlerService', () => {
   let errorHandlerService: ErrorHandlerService;
   let mockAppInsightsService: AppInsightsService;
-  let mockRouter: Router;
 
   beforeEach(() => {
     // Create a TestBed configuration with the ErrorHandlerService
@@ -28,7 +25,6 @@ describe('ErrorHandlerService', () => {
     // Get instances of the services and injector
     errorHandlerService = TestBed.inject(ErrorHandlerService);
     mockAppInsightsService = TestBed.inject(AppInsightsService);
-    mockRouter = TestBed.inject(Router);
   });
 
   it('should be created', () => {
@@ -42,14 +38,5 @@ describe('ErrorHandlerService', () => {
     errorHandlerService.handleError(error);
 
     expect(logExceptionSpy).toHaveBeenCalledWith(error);
-  });
-
-  it('should route to internal-error page on 500 response', () => {
-    const error = new HttpErrorResponse({ status: 500 });
-    const navigateSpy = jest.spyOn(mockRouter, 'navigateByUrl');
-
-    errorHandlerService.handleError(error);
-
-    expect(navigateSpy).toHaveBeenCalledWith('internal-error');
   });
 });

--- a/src/app/services/error/error-handler.service.spec.ts
+++ b/src/app/services/error/error-handler.service.spec.ts
@@ -1,11 +1,14 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { ErrorHandlerService } from './error-handler.service';
 
 describe('ErrorHandlerService', () => {
   let errorHandlerService: ErrorHandlerService;
   let mockAppInsightsService: AppInsightsService;
+  let mockRouter: Router;
 
   beforeEach(() => {
     // Create a TestBed configuration with the ErrorHandlerService
@@ -25,6 +28,7 @@ describe('ErrorHandlerService', () => {
     // Get instances of the services and injector
     errorHandlerService = TestBed.inject(ErrorHandlerService);
     mockAppInsightsService = TestBed.inject(AppInsightsService);
+    mockRouter = TestBed.inject(Router);
   });
 
   it('should be created', () => {
@@ -38,5 +42,14 @@ describe('ErrorHandlerService', () => {
     errorHandlerService.handleError(error);
 
     expect(logExceptionSpy).toHaveBeenCalledWith(error);
+  });
+
+  it('should route to internal-error page on 500 response', () => {
+    const error = new HttpErrorResponse({ status: 500 });
+    const navigateSpy = jest.spyOn(mockRouter, 'navigateByUrl');
+
+    errorHandlerService.handleError(error);
+
+    expect(navigateSpy).toHaveBeenCalledWith('internal-error');
   });
 });

--- a/src/app/services/error/error-handler.service.ts
+++ b/src/app/services/error/error-handler.service.ts
@@ -1,16 +1,11 @@
-import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, Injectable, Injector } from '@angular/core';
-import { Router } from '@angular/router';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ErrorHandlerService extends ErrorHandler {
-  constructor(
-    private injector: Injector,
-    private router: Router
-  ) {
+  constructor(private injector: Injector) {
     super();
   }
 
@@ -18,16 +13,5 @@ export class ErrorHandlerService extends ErrorHandler {
     const appInsightsService = this.injector.get(AppInsightsService);
     console.error('Exception', error);
     appInsightsService.logException(error);
-    this.statusChecker(error as HttpErrorResponse);
-  }
-
-  private statusChecker(error: HttpErrorResponse) {
-    const status = error.status;
-    switch (status) {
-      case 500: {
-        this.router.navigateByUrl('internal-error');
-        break;
-      }
-    }
   }
 }

--- a/src/app/services/error/error-handler.service.ts
+++ b/src/app/services/error/error-handler.service.ts
@@ -1,11 +1,16 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import { Router } from '@angular/router';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ErrorHandlerService extends ErrorHandler {
-  constructor(private injector: Injector) {
+  constructor(
+    private injector: Injector,
+    private router: Router
+  ) {
     super();
   }
 
@@ -13,5 +18,16 @@ export class ErrorHandlerService extends ErrorHandler {
     const appInsightsService = this.injector.get(AppInsightsService);
     console.error('Exception', error);
     appInsightsService.logException(error);
+    this.statusChecker(error as HttpErrorResponse);
+  }
+
+  private statusChecker(error: HttpErrorResponse) {
+    const status = error.status;
+    switch (status) {
+      case 500: {
+        this.router.navigateByUrl('internal-error');
+        break;
+      }
+    }
   }
 }

--- a/src/app/services/error/error-message.service.spec.ts
+++ b/src/app/services/error/error-message.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { HeaderService } from '@services/header/header.service';
+import { ErrorMessageService } from './error-message.service';
+
+describe('ErrorMessageService', () => {
+  let service: ErrorMessageService;
+  let mockRouter: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [HeaderService] });
+    service = TestBed.inject(ErrorMessageService);
+    mockRouter = TestBed.inject(Router);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should route to internal-error page on 500 response', () => {
+    const error = new HttpErrorResponse({ status: 500 });
+    const navigateSpy = jest.spyOn(mockRouter, 'navigateByUrl');
+
+    service.handleErrorMessage(error);
+
+    expect(navigateSpy).toHaveBeenCalledWith('internal-error');
+  });
+});

--- a/src/app/services/error/error-message.service.ts
+++ b/src/app/services/error/error-message.service.ts
@@ -1,0 +1,52 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { ErrorMessage } from '@darts-types/error-message.interface';
+import { HeaderService } from '@services/header/header.service';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+//Contains endpoints where errors are handled in their component
+const subscribedEndpoints = ['/api/cases/search'];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorMessageService {
+  private errorMessage: BehaviorSubject<ErrorMessage | null> = new BehaviorSubject<ErrorMessage | null>(null);
+  readonly errorMessage$: Observable<ErrorMessage | null> = this.errorMessage.asObservable();
+
+  constructor(
+    private headerService: HeaderService,
+    private router: Router
+  ) {}
+
+  handleErrorMessage(error: HttpErrorResponse) {
+    error.error && this.setErrorMessage({ status: error.status, type: error.error.type });
+    this.handleOtherPages(error);
+  }
+
+  setErrorMessage(error: ErrorMessage) {
+    this.errorMessage.next(error);
+  }
+
+  updateDisplayType(type: 'PAGE' | 'COMPONENT'): void {
+    const currentError: ErrorMessage | null = this.errorMessage.getValue();
+    if (currentError) {
+      currentError.display = type;
+      this.errorMessage.next(currentError);
+    }
+  }
+
+  //Used to handle other components/endpoints that do not subscribe to the error
+  private handleOtherPages(error: HttpErrorResponse) {
+    const isIncluded = subscribedEndpoints.some((endpoint) => error.url?.includes(endpoint));
+    if (error.status === 500 && !isIncluded) {
+      this.showInternalError();
+    }
+  }
+
+  private showInternalError() {
+    this.router.navigateByUrl('internal-error');
+    setTimeout(() => this.headerService.hideNavigation(), 0);
+  }
+}

--- a/src/app/types/error-message.interface.ts
+++ b/src/app/types/error-message.interface.ts
@@ -1,0 +1,9 @@
+export interface ErrorMessage {
+  message?: string[];
+  type?: string;
+  endpoint?: string;
+  route?: string;
+  display?: 'COMPONENT' | 'PAGE';
+  status: number;
+  statusText?: string;
+}


### PR DESCRIPTION
DMP-1323 Generic internal server error page, unit tests, functional tests, stub updated

Now handles both page and component style errors, errors not handled in component i.e. generic 500 errors will default to page redirect.

To test against local stub, enter "INTERNAL_SERVER_ERROR" in case number search for component error.


- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
