### PR TITLE
Allow secure cookies to be disabled

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -8,5 +8,8 @@
   "authentication": {
     "azureAdB2cOriginHost": "DARTS_AZUREAD_B2C_ORIGIN_HOST",
     "allowAuthBootstrap": "DARTS_ALLOW_AUTH_BOOTSTRAP"
+  },
+  "session": {
+    "useSecureCookies": "DARTS_SESSION_USE_SECURE_COOKIES"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -9,6 +9,10 @@
     "azureAdB2cOriginHost": "*",
     "allowAuthBootstrap": "false"
   },
+  "session": {
+    "useSecureCookies": "true",
+    "ttlInSeconds": 1200
+  },
   "secrets": {
     "darts": {
       "AppInsightsInstrumentationKey": "00000000-0000-0000-0000-000000000000",

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,5 @@
+{
+  "session": {
+    "useSecureCookies": "false"
+  }
+}

--- a/server/middleware/session.ts
+++ b/server/middleware/session.ts
@@ -20,7 +20,7 @@ export default () => {
     });
     sessionMiddleware.store = redisStore;
 
-    if (sessionMiddleware.cookie) {
+    if (config.get('session.useSecureCookies') === 'true' && sessionMiddleware.cookie) {
       sessionMiddleware.cookie.secure = true; // serve secure cookies
     }
   }


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

We need to be able to disable using of secure cookies in the staging environment. This is to enable a test which does not go through SSL.

- default to on if NODE_ENV is "production"
- override development env to false

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
