### PR TITLE
DMP-1383 - Inject user_id header for all DARTS API requests

### DIFF
--- a/server/controllers/api.ts
+++ b/server/controllers/api.ts
@@ -17,6 +17,9 @@ function proxyMiddleware() {
         if (req.session.securityToken.accessToken) {
           proxyReq.setHeader('Authorization', `Bearer ${req.session.securityToken.accessToken}`);
         }
+        if (req.session.securityToken.userState?.userId) {
+          proxyReq.setHeader('user_id', req.session.securityToken.userState.userId);
+        }
       }
       if (req.path.startsWith('/audio/preview')) {
         console.log('onProxyReq::proxyReq', req.path, proxyReq.getHeaders());

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -41,7 +41,7 @@ export class AudioRequestService {
 
   getAudioRequests(expired: boolean): Observable<UserAudioRequest[]> {
     return this.userProfile$.pipe(
-      switchMap((userState) => {
+      switchMap(() => {
         return this.http
           .get<UserAudioRequest[]>(`api/audio-requests`, {
             params: { expired },
@@ -84,7 +84,7 @@ export class AudioRequestService {
 
   getUnreadCount(): Observable<number> {
     return this.userProfile$.pipe(
-      switchMap((userState) =>
+      switchMap(() =>
         this.http
           .get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {
           })

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -84,12 +84,7 @@ export class AudioRequestService {
 
   getUnreadCount(): Observable<number> {
     return this.userProfile$.pipe(
-      switchMap(() =>
-        this.http
-          .get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {
-          })
-          .pipe(map((res) => res.count))
-      )
+      switchMap(() => this.http.get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {}).pipe(map((res) => res.count)))
     );
   }
 

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -87,7 +87,6 @@ export class AudioRequestService {
       switchMap((userState) =>
         this.http
           .get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {
-            headers: { user_id: userState.userId.toString() },
           })
           .pipe(map((res) => res.count))
       )

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -40,15 +40,11 @@ export class AudioRequestService {
   );
 
   getAudioRequests(expired: boolean): Observable<UserAudioRequest[]> {
-    return this.userProfile$.pipe(
-      switchMap(() => {
-        return this.http
-          .get<UserAudioRequest[]>(`api/audio-requests`, {
-            params: { expired },
-          })
-          .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'T00:00:00Z' }))));
+    return this.http
+      .get<UserAudioRequest[]>(`api/audio-requests`, {
+        params: { expired },
       })
-    );
+      .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'T00:00:00Z' }))));
   }
 
   deleteAudioRequests(mediaRequestId: number): Observable<HttpResponse<Response>> {
@@ -83,9 +79,7 @@ export class AudioRequestService {
   }
 
   getUnreadCount(): Observable<number> {
-    return this.userProfile$.pipe(
-      switchMap(() => this.http.get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {}).pipe(map((res) => res.count)))
-    );
+    return this.http.get<{ count: number }>(UNREAD_AUDIO_COUNT_PATH, {}).pipe(map((res) => res.count));
   }
 
   private updateUnread(audioRequests: UserAudioRequest[]) {

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -44,7 +44,6 @@ export class AudioRequestService {
       switchMap((userState) => {
         return this.http
           .get<UserAudioRequest[]>(`api/audio-requests`, {
-            headers: { user_id: userState.userId.toString() },
             params: { expired },
           })
           .pipe(map((requests) => requests.map((r) => ({ ...r, hearing_date: r.hearing_date + 'T00:00:00Z' }))));


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-1383](https://tools.hmcts.net/jira/browse/DMP-1383)

### Change description ###

- Set header in proxyReq to include **user__id** from **securityToken.userState.userId**
- Removed user_id header being set in **getUnreadCount** and **getAudioRequests**  from userState