### PR TITLE
DMP-1610 Default name for transcription file, cypress updated

### DIFF
--- a/cypress/e2e/functional/hearing-transcripts-spec.cy.js
+++ b/cypress/e2e/functional/hearing-transcripts-spec.cy.js
@@ -19,7 +19,7 @@ describe('Hearing Transcripts', () => {
     cy.get('#hearingsTable').should('contain', '1 Sep 2023');
     cy.get('#hearingsTable a').contains('1 Sep 2023').click();
     cy.get(':nth-child(2) > .moj-sub-navigation__link').click();
-    cy.get('#transcription-count').should('contain', 2);
+    cy.get('#transcription-count').should('contain', 3);
     cy.get('.govuk-button').should('contain', 'Request a new transcript');
     cy.get('#transcriptsTable').should('contain', 'Sentencing remarks');
     cy.a11y();

--- a/cypress/e2e/functional/view-transcript.cy.js
+++ b/cypress/e2e/functional/view-transcript.cy.js
@@ -33,8 +33,26 @@ describe('View Transcript', () => {
     cy.contains('Complete').parents('tr').should('contain', 'Sentencing remarks');
     cy.get('.govuk-button').should('contain', 'Request a new transcript');
     cy.get('.govuk-tag--green').should('contain', 'Complete');
-    cy.contains('Complete').parents('tr').contains('View').click();
+    cy.contains('12 Oct 2023').parents('tr').contains('View').click();
+    cy.get('h1').should('contain', 'C20220620001_0.docx');
     cy.contains('Case ID').parents('tr').should('contain', 'C20220620001');
+    cy.get('.govuk-body-m').should('contain', 'Section 4(2) of the Contempt of Court Act 1981');
+    cy.a11y();
+  });
+
+  it('should show default filename when it does not exist on view transcripts', () => {
+    cy.get('a').contains('C20220620001').click();
+    cy.get('h1').should('contain', 'C20220620001');
+    cy.get('#hearingsTable').should('contain', '1 Sep 2023');
+    cy.get('#hearingsTable a').contains('1 Sep 2023').click();
+    cy.get('.moj-sub-navigation__link').contains('Transcripts').click();
+    cy.get('.govuk-caption-l').should('contain', 'Hearing');
+    cy.get('.flex-space-between > .govuk-heading-m').should('contain', 'Transcripts for this hearing');
+    cy.contains('Complete').parents('tr').should('contain', 'Sentencing remarks');
+    cy.get('.govuk-button').should('contain', 'Request a new transcript');
+    cy.get('.govuk-tag--green').should('contain', 'Complete');
+    cy.contains('21 Oct 2023').parents('tr').contains('View').click();
+    cy.get('h1').should('contain', 'Document not found');
     cy.get('.govuk-body-m').should('contain', 'Section 4(2) of the Contempt of Court Act 1981');
   });
 });

--- a/darts-api-stub/hearings/hearings.js
+++ b/darts-api-stub/hearings/hearings.js
@@ -4,8 +4,8 @@ const router = express.Router();
 
 const transcriptOne = [
   {
-    tra_id: 1,
-    hea_id: 2,
+    tra_id: 0,
+    hea_id: 1,
     hearing_date: '2023-10-12',
     type: 'Sentencing remarks',
     requested_on: '2023-10-12',
@@ -14,10 +14,19 @@ const transcriptOne = [
   },
   {
     tra_id: 1,
-    hea_id: 2,
+    hea_id: 1,
     hearing_date: '2023-10-12',
     type: 'Sentencing remarks',
     requested_on: '2023-10-12',
+    requested_by_name: 'Joe Bloggs',
+    status: 'Complete',
+  },
+  {
+    tra_id: 2,
+    hea_id: 1,
+    hearing_date: '2023-10-12',
+    type: 'Sentencing remarks',
+    requested_on: '2023-10-21',
     requested_by_name: 'Joe Bloggs',
     status: 'Complete',
   },

--- a/darts-api-stub/transcriptions/transcriptions.js
+++ b/darts-api-stub/transcriptions/transcriptions.js
@@ -18,6 +18,19 @@ const mockTranscriptionDetails = {
   transcription_end_ts: '2023-06-26T16:00:00Z',
 };
 
+const mockTranscriptionDetailsNoName = {
+  case_id: 1,
+  case_number: 'C20220620001',
+  courthouse: 'Swansea',
+  defendants: ['Defendant Dave'],
+  judges: ['HHJ M. Hussain KC	'],
+  hearing_date: '2023-11-08',
+  urgency: 'Standard',
+  request_type: 'Specified Times',
+  transcription_start_ts: '2023-06-26T13:00:00Z',
+  transcription_end_ts: '2023-06-26T16:00:00Z',
+};
+
 router.get('/types', (req, res) => {
   res.send([
     { trt_id: 0, description: 'Duplicate' },
@@ -52,6 +65,7 @@ router.get('/:transcriptId', (req, res) => {
         status: 403,
       };
       res.status(403).send(error403);
+      break;
     case '404':
       const error404 = {
         type: 'TRANSCRIPTION_101',
@@ -59,6 +73,13 @@ router.get('/:transcriptId', (req, res) => {
         status: 404,
       };
       res.status(404).send(error404);
+      break;
+    case '1':
+      res.status(200).send(mockTranscriptionDetails);
+      break;
+    case '2':
+      res.status(200).send(mockTranscriptionDetailsNoName);
+      break;
     default:
       res.status(200).send(mockTranscriptionDetails);
   }

--- a/src/app/services/transcription/transcription.service.ts
+++ b/src/app/services/transcription/transcription.service.ts
@@ -44,6 +44,11 @@ export class TranscriptionService {
   }
 
   getTranscriptionDetails(transcriptId: number): Observable<TranscriptionDetails> {
-    return this.http.get<TranscriptionDetails>(`/api/transcriptions/${transcriptId}`);
+    return this.http.get<TranscriptionDetails>(`/api/transcriptions/${transcriptId}`).pipe(
+      map((transcription: TranscriptionDetails) => {
+        transcription.transcript_file_name = transcription.transcript_file_name ?? 'Document not found';
+        return transcription;
+      })
+    );
   }
 }


### PR DESCRIPTION
DMP-1610

Default name added for transcription file to fix breadcrumb on staging due to correlating data not existing in transcription_document

Cypress updated


- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
