### PR TITLE
Your Audio - Prevent extra network call on load

### DIFF
--- a/src/app/components/audios/audios.component.ts
+++ b/src/app/components/audios/audios.component.ts
@@ -10,7 +10,7 @@ import { TableRowTemplateDirective } from '@directives/table-row-template.direct
 import { UnreadIconDirective } from '@directives/unread-icon.directive';
 import { AudioRequestService } from '@services/audio-request/audio-request.service';
 import { HeaderService } from '@services/header/header.service';
-import { combineLatest, forkJoin, map, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, forkJoin, map, shareReplay, switchMap } from 'rxjs';
 import { AudioDeleteComponent } from './audio-delete/audio-delete.component';
 
 @Component({
@@ -34,6 +34,8 @@ export class AudiosComponent {
   headerService = inject(HeaderService);
   audioService = inject(AudioRequestService);
   router = inject(Router);
+
+  private refresh$ = new BehaviorSubject<void>(undefined);
 
   selectedAudioRequests: UserAudioRequestRow[] = [];
 
@@ -66,8 +68,15 @@ export class AudiosComponent {
   readyColumns = [{ name: '', prop: '' }, ...this.columns, { name: '', prop: '' }]; //Empty columns for unread icon and view link
 
   constructor() {
-    this.audioRequests$ = this.audioService.audioRequests$;
-    this.expiredAudioRequests$ = this.audioService.expiredAudioRequests$;
+    this.audioRequests$ = this.refresh$.pipe(
+      switchMap(() => this.audioService.audioRequests$),
+      shareReplay(1)
+    );
+
+    this.expiredAudioRequests$ = this.refresh$.pipe(
+      switchMap(() => this.audioService.expiredAudioRequests$),
+      shareReplay(1)
+    );
 
     this.inProgessRows$ = this.audioRequests$.pipe(
       map((audioRequests) => this.filterInProgressRequests(audioRequests)),
@@ -144,6 +153,8 @@ export class AudiosComponent {
       next: () => (this.isDeleting = false),
       error: () => (this.isDeleting = false),
     });
+
+    this.refresh$.next();
   }
 
   onDeleteCancelled() {

--- a/src/app/services/audio-request/audio-request.service.ts
+++ b/src/app/services/audio-request/audio-request.service.ts
@@ -2,7 +2,6 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { UserAudioRequestRow } from '@darts-types/index';
 import { AudioRequestType, UserAudioRequest } from '@darts-types/user-audio-request.interface';
-import { UserService } from '@services/user/user.service';
 import { BehaviorSubject, Observable, map, merge, switchMap, tap, timer } from 'rxjs';
 
 export const UNREAD_AUDIO_COUNT_PATH = 'api/audio-requests/not-accessed-count';
@@ -11,15 +10,14 @@ export const UNREAD_AUDIO_COUNT_PATH = 'api/audio-requests/not-accessed-count';
 })
 export class AudioRequestService {
   http = inject(HttpClient);
-  userProfile$ = inject(UserService).userProfile$;
 
   // Defined in seconds
   private readonly POLL_INTERVAL = 60;
   private readonly UNREAD_COUNT_POLL_INTERVAL = 30;
 
   // Save unread count in memory
-  private unreadCount: BehaviorSubject<number> = new BehaviorSubject<number>(0);
-  readonly unreadCount$: Observable<number> = this.unreadCount.asObservable();
+  private unreadCount = new BehaviorSubject<number>(0);
+  readonly unreadCount$ = this.unreadCount.asObservable();
 
   // Store audio request when clicking 'View' on 'Your Audio' screen
   audioRequestView!: UserAudioRequestRow;


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

The endpoint: `/audio-requests?expired=false` was being called twice on, on load, on 'Your Audio' screen.

This was due to multiple subscribes in the template causing multiple/duplicate HTTP requests.

This PR fixes the issue by using shareReplay() to cache the data at the component level so that any extra async pipes / subscriptions get the previously fetched data.

This works with existing polling functionality.

Wrapped the service call inside a refresh$ observable allows us to manually refresh the data when necessary such as after a delete operation to get the latest data from the server.

Removed some redundant code from the AudioRequestService