### PR TITLE
DMP-1746: Add urgency sort to required tables

### DIFF
--- a/src/app/components/transcriptions/transcription-requests/transcription-requests.component.html
+++ b/src/app/components/transcriptions/transcription-requests/transcription-requests.component.html
@@ -15,7 +15,9 @@
       <td class="govuk-table__cell">{{ row.requested_ts | date: 'dd MMM yyyy HH:mm' }}</td>
       <td class="govuk-table__cell">{{ row.is_manual ? 'Manual' : 'Automated' }}</td>
       <td class="govuk-table__cell">
-        <span [ngClass]="row.urgency === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{ row.urgency }}</span>
+        <span [ngClass]="row.urgency.description === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{
+          row.urgency.description
+        }}</span>
       </td>
       <td class="govuk-table__cell">
         <a [routerLink]="[row.transcription_id]">View</a>

--- a/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
+++ b/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
@@ -5,6 +5,7 @@ import { DataTableComponent } from '@common/data-table/data-table.component';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { DatatableColumn } from '@darts-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { SortService } from '@services/sort/sort.service';
 import { TranscriptionService } from '@services/transcription/transcription.service';
 
 @Component({
@@ -16,6 +17,7 @@ import { TranscriptionService } from '@services/transcription/transcription.serv
 })
 export class TranscriptionRequestsComponent {
   transcriptionService = inject(TranscriptionService);
+  customSortFunctionService = inject(SortService);
 
   columns: DatatableColumn[] = [
     { name: 'Case ID', prop: 'case_number', sortable: true },
@@ -24,7 +26,12 @@ export class TranscriptionRequestsComponent {
     { name: 'Type', prop: 'transcription_type', sortable: true },
     { name: 'Requested on', prop: 'requested_ts', sortable: true },
     { name: 'Method', prop: 'is_manual', sortable: true },
-    { name: 'Urgency', prop: 'urgency', sortable: true },
+    {
+      name: 'Urgency',
+      prop: 'urgency',
+      sortable: true,
+      customSortFn: this.customSortFunctionService.sortByUrgencyPriorityOrder,
+    },
     { name: '', prop: '' },
   ];
 

--- a/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
+++ b/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
@@ -3,6 +3,7 @@ import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { LoadingComponent } from '@common/loading/loading.component';
+import { transcriptTableColumns } from '@constants/transcription-columns';
 import { DatatableColumn } from '@darts-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
 import { SortService } from '@services/sort/sort.service';
@@ -20,11 +21,7 @@ export class TranscriptionRequestsComponent {
   sortService = inject(SortService);
 
   columns: DatatableColumn[] = [
-    { name: 'Case ID', prop: 'case_number', sortable: true },
-    { name: 'Court', prop: 'courthouse_name', sortable: true },
-    { name: 'Hearing date', prop: 'hearing_date', sortable: true },
-    { name: 'Type', prop: 'transcription_type', sortable: true },
-    { name: 'Requested on', prop: 'requested_ts', sortable: true },
+    ...transcriptTableColumns,
     { name: 'Method', prop: 'is_manual', sortable: true },
     {
       name: 'Urgency',

--- a/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
+++ b/src/app/components/transcriptions/transcription-requests/transcription-requests.component.ts
@@ -17,7 +17,7 @@ import { TranscriptionService } from '@services/transcription/transcription.serv
 })
 export class TranscriptionRequestsComponent {
   transcriptionService = inject(TranscriptionService);
-  customSortFunctionService = inject(SortService);
+  sortService = inject(SortService);
 
   columns: DatatableColumn[] = [
     { name: 'Case ID', prop: 'case_number', sortable: true },
@@ -30,7 +30,7 @@ export class TranscriptionRequestsComponent {
       name: 'Urgency',
       prop: 'urgency',
       sortable: true,
-      customSortFn: this.customSortFunctionService.sortByUrgencyPriorityOrder,
+      customSortFn: this.sortService.sortByUrgencyPriorityOrder,
     },
     { name: '', prop: '' },
   ];

--- a/src/app/components/transcriptions/transcriptions.component.html
+++ b/src/app/components/transcriptions/transcriptions.component.html
@@ -8,7 +8,9 @@
     <strong class="govuk-tag" [ngClass]="transcriptStatusClassMap[row.status]">{{ row.status }}</strong>
   </td>
   <td class="govuk-table__cell">
-    <span [ngClass]="row.urgency === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{ row.urgency }}</span>
+    <span [ngClass]="row.urgency.description === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{
+      row.urgency.description
+    }}</span>
   </td>
 </ng-template>
 
@@ -112,8 +114,8 @@
           <td class="govuk-table__cell">{{ row.requested_ts | date: 'dd MMM yyyy HH:mm' }}</td>
           <td class="govuk-table__cell">{{ row.transcription_id }}</td>
           <td class="govuk-table__cell">
-            <span [ngClass]="row.urgency?.description === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{
-              row.urgency?.description
+            <span [ngClass]="row.urgency.description === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{
+              row.urgency.description
             }}</span>
           </td>
           <td class="govuk-table__cell">

--- a/src/app/components/transcriptions/transcriptions.component.ts
+++ b/src/app/components/transcriptions/transcriptions.component.ts
@@ -8,6 +8,7 @@ import { LoadingComponent } from '@common/loading/loading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { ForbiddenComponent } from '@components/error/forbidden/forbidden.component';
 import { transcriptStatusClassMap } from '@constants/transcript-status-class-map';
+import { transcriptTableColumns } from '@constants/transcription-columns';
 import { DatatableColumn, UserTranscriptionRequestVm } from '@darts-types/index';
 import { TabDirective } from '@directives/tab.directive';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
@@ -42,11 +43,7 @@ export class TranscriptionsComponent {
   transcriptStatusClassMap = transcriptStatusClassMap;
 
   columns: DatatableColumn[] = [
-    { name: 'Case ID', prop: 'case_number', sortable: true },
-    { name: 'Court', prop: 'courthouse_name', sortable: true },
-    { name: 'Hearing date', prop: 'hearing_date', sortable: true },
-    { name: 'Type', prop: 'transcription_type', sortable: true },
-    { name: 'Requested on', prop: 'requested_ts', sortable: true },
+    ...transcriptTableColumns,
     { name: 'Status', prop: 'status', sortable: true },
     {
       name: 'Urgency',

--- a/src/app/components/transcriptions/transcriptions.component.ts
+++ b/src/app/components/transcriptions/transcriptions.component.ts
@@ -38,7 +38,7 @@ export class TranscriptionsComponent {
   transcriptService = inject(TranscriptionService);
   userService = inject(UserService);
   userState = inject(ActivatedRoute).snapshot.data.userState;
-  customSortFunctionService = inject(SortService);
+  sortService = inject(SortService);
   transcriptStatusClassMap = transcriptStatusClassMap;
 
   columns: DatatableColumn[] = [
@@ -52,7 +52,7 @@ export class TranscriptionsComponent {
       name: 'Urgency',
       prop: 'urgency',
       sortable: true,
-      customSortFn: this.customSortFunctionService.sortByUrgencyPriorityOrder,
+      customSortFn: this.sortService.sortByUrgencyPriorityOrder,
     },
   ];
   readyColumns = [...this.columns, { name: '', prop: '' }]; //Empty column header for view link

--- a/src/app/components/transcriptions/transcriptions.component.ts
+++ b/src/app/components/transcriptions/transcriptions.component.ts
@@ -8,10 +8,10 @@ import { LoadingComponent } from '@common/loading/loading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { ForbiddenComponent } from '@components/error/forbidden/forbidden.component';
 import { transcriptStatusClassMap } from '@constants/transcript-status-class-map';
-import { DatatableColumn, UserTranscriptionRequest } from '@darts-types/index';
+import { DatatableColumn, UserTranscriptionRequestVm } from '@darts-types/index';
 import { TabDirective } from '@directives/tab.directive';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
-import { TableCustomSortFunctionsService } from '@services/custom-sort/table-custom-sort-functions.service';
+import { SortService } from '@services/sort/sort.service';
 import { TranscriptionService } from '@services/transcription/transcription.service';
 import { UserService } from '@services/user/user.service';
 import { BehaviorSubject, combineLatest, map, shareReplay, switchMap } from 'rxjs';
@@ -38,7 +38,7 @@ export class TranscriptionsComponent {
   transcriptService = inject(TranscriptionService);
   userService = inject(UserService);
   userState = inject(ActivatedRoute).snapshot.data.userState;
-  customSortFunctionService = inject(TableCustomSortFunctionsService);
+  customSortFunctionService = inject(SortService);
   transcriptStatusClassMap = transcriptStatusClassMap;
 
   columns: DatatableColumn[] = [
@@ -63,7 +63,7 @@ export class TranscriptionsComponent {
   deleteColumns = this.columns.map((c) => ({ ...c, sortable: false }));
 
   isDeleting = false;
-  selectedRequests = [] as UserTranscriptionRequest[];
+  selectedRequests = [] as UserTranscriptionRequestVm[];
 
   private refresh$ = new BehaviorSubject<void>(undefined);
 
@@ -81,15 +81,13 @@ export class TranscriptionsComponent {
     ),
     approverRequests: this.requests$.pipe(map((requests) => requests.approver_transcriptions)),
   });
-  approverRequests$ = this.requests$
-    .pipe(map((requests) => requests.approver_transcriptions))
-    .pipe(this.transcriptService.mapTranscriptUrgencies());
+  approverRequests$ = this.requests$.pipe(map((requests) => requests.approver_transcriptions));
 
-  private filterInProgressRequests(requests: UserTranscriptionRequest[]): UserTranscriptionRequest[] {
+  private filterInProgressRequests(requests: UserTranscriptionRequestVm[]): UserTranscriptionRequestVm[] {
     return requests.filter((r) => r.status === 'Awaiting Authorisation' || r.status === 'With Transcriber');
   }
 
-  private filterReadyRequests(requests: UserTranscriptionRequest[]): UserTranscriptionRequest[] {
+  private filterReadyRequests(requests: UserTranscriptionRequestVm[]): UserTranscriptionRequestVm[] {
     return requests.filter((r) => r.status === 'Complete' || r.status === 'Rejected');
   }
 

--- a/src/app/components/your-work/your-work.component.html
+++ b/src/app/components/your-work/your-work.component.html
@@ -5,7 +5,9 @@
   <td class="govuk-table__cell">{{ row.transcription_type }}</td>
   <td class="govuk-table__cell">{{ row.requested_ts | date: 'dd MMM yyyy HH:mm' }}</td>
   <td class="govuk-table__cell">
-    <span [ngClass]="row.urgency === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{ row.urgency }}</span>
+    <span [ngClass]="row.urgency.description === 'Overnight' ? 'moj-badge moj-badge--red' : ''">{{
+      row.urgency.description
+    }}</span>
   </td>
   <td class="govuk-table__cell">
     <a [routerLink]="['/work', row.transcription_id]">View</a>

--- a/src/app/components/your-work/your-work.component.spec.ts
+++ b/src/app/components/your-work/your-work.component.spec.ts
@@ -1,14 +1,14 @@
 import { DATE_PIPE_DEFAULT_OPTIONS, DatePipe } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { WorkRequest } from '@darts-types/index';
+import { WorkRequestVm } from '@darts-types/index';
 import { TranscriptionService } from '@services/transcription/transcription.service';
 import { of } from 'rxjs';
 
 import { RouterTestingModule } from '@angular/router/testing';
 import { YourWorkComponent } from './your-work.component';
 
-const MOCK_WORK_REQUESTS: WorkRequest[] = [
+const MOCK_WORK_REQUESTS: WorkRequestVm[] = [
   {
     transcription_id: 1,
     case_id: 3,
@@ -17,7 +17,7 @@ const MOCK_WORK_REQUESTS: WorkRequest[] = [
     hearing_date: '2023-08-06T00:00:00Z',
     transcription_type: 'Court Log',
     status: 'With Transcriber',
-    urgency: 'Overnight',
+    urgency: { transcription_urgency_id: 1, description: 'Overnight', priority_order: 1 },
     requested_ts: '2023-08-12T13:00:00Z',
     state_change_ts: '2023-08-13T13:00:00Z',
     is_manual: true,
@@ -30,7 +30,7 @@ const MOCK_WORK_REQUESTS: WorkRequest[] = [
     hearing_date: '2023-06-10T00:00:00Z',
     transcription_type: 'Court Log',
     status: 'Complete',
-    urgency: 'Up to 3 Working days',
+    urgency: { transcription_urgency_id: 1, description: 'Up to 3 Working days', priority_order: 1 },
     requested_ts: '2023-06-26T13:00:00Z',
     state_change_ts: '2023-06-27T13:00:00Z',
     is_manual: true,

--- a/src/app/components/your-work/your-work.component.ts
+++ b/src/app/components/your-work/your-work.component.ts
@@ -4,6 +4,7 @@ import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
+import { transcriptTableColumns } from '@constants/transcription-columns';
 import { DatatableColumn, WorkRequestVm } from '@darts-types/index';
 import { TabDirective } from '@directives/tab.directive';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
@@ -31,11 +32,7 @@ export class YourWorkComponent {
   sortService = inject(SortService);
 
   columns: DatatableColumn[] = [
-    { name: 'Case ID', prop: 'case_number', sortable: true },
-    { name: 'Court', prop: 'courthouse_name', sortable: true },
-    { name: 'Hearing date', prop: 'hearing_date', sortable: true },
-    { name: 'Type', prop: 'transcription_type', sortable: true },
-    { name: 'Requested on', prop: 'requested_ts', sortable: true },
+    ...transcriptTableColumns,
     {
       name: 'Urgency',
       prop: 'urgency',

--- a/src/app/components/your-work/your-work.component.ts
+++ b/src/app/components/your-work/your-work.component.ts
@@ -28,7 +28,7 @@ import { combineLatest, map, shareReplay } from 'rxjs';
 })
 export class YourWorkComponent {
   transcriptionService = inject(TranscriptionService);
-  customSortService = inject(SortService);
+  sortService = inject(SortService);
 
   columns: DatatableColumn[] = [
     { name: 'Case ID', prop: 'case_number', sortable: true },
@@ -40,7 +40,7 @@ export class YourWorkComponent {
       name: 'Urgency',
       prop: 'urgency',
       sortable: true,
-      customSortFn: this.customSortService.sortByUrgencyPriorityOrder,
+      customSortFn: this.sortService.sortByUrgencyPriorityOrder,
     },
   ];
 

--- a/src/app/components/your-work/your-work.component.ts
+++ b/src/app/components/your-work/your-work.component.ts
@@ -4,9 +4,10 @@ import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
-import { DatatableColumn, WorkRequest } from '@darts-types/index';
+import { DatatableColumn, WorkRequestVm } from '@darts-types/index';
 import { TabDirective } from '@directives/tab.directive';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { SortService } from '@services/sort/sort.service';
 import { TranscriptionService } from '@services/transcription/transcription.service';
 import { combineLatest, map, shareReplay } from 'rxjs';
 
@@ -27,6 +28,7 @@ import { combineLatest, map, shareReplay } from 'rxjs';
 })
 export class YourWorkComponent {
   transcriptionService = inject(TranscriptionService);
+  customSortService = inject(SortService);
 
   columns: DatatableColumn[] = [
     { name: 'Case ID', prop: 'case_number', sortable: true },
@@ -34,7 +36,12 @@ export class YourWorkComponent {
     { name: 'Hearing date', prop: 'hearing_date', sortable: true },
     { name: 'Type', prop: 'transcription_type', sortable: true },
     { name: 'Requested on', prop: 'requested_ts', sortable: true },
-    { name: 'Urgency', prop: 'urgency', sortable: true },
+    {
+      name: 'Urgency',
+      prop: 'urgency',
+      sortable: true,
+      customSortFn: this.customSortService.sortByUrgencyPriorityOrder,
+    },
   ];
 
   readyColumns = [...this.columns, { name: '', prop: '' }]; // Empty column header for view link
@@ -46,11 +53,11 @@ export class YourWorkComponent {
     completedRequests: this.requests$.pipe(map((requests) => this.filterCompletedRequests(requests))),
   });
 
-  private filterTodoRequests(requests: WorkRequest[]): WorkRequest[] {
+  private filterTodoRequests(requests: WorkRequestVm[]): WorkRequestVm[] {
     return requests.filter((r) => r.status === 'With Transcriber');
   }
 
-  private filterCompletedRequests(requests: WorkRequest[]): WorkRequest[] {
+  private filterCompletedRequests(requests: WorkRequestVm[]): WorkRequestVm[] {
     return requests.filter((r) => r.status === 'Complete');
   }
 }

--- a/src/app/constants/transcription-columns.ts
+++ b/src/app/constants/transcription-columns.ts
@@ -1,0 +1,7 @@
+export const transcriptTableColumns = [
+  { name: 'Case ID', prop: 'case_number', sortable: true },
+  { name: 'Court', prop: 'courthouse_name', sortable: true },
+  { name: 'Hearing date', prop: 'hearing_date', sortable: true },
+  { name: 'Type', prop: 'transcription_type', sortable: true },
+  { name: 'Requested on', prop: 'requested_ts', sortable: true },
+];

--- a/src/app/services/sort/sort.service.spec.ts
+++ b/src/app/services/sort/sort.service.spec.ts
@@ -1,10 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-
 import { TranscriptionUrgency } from '@darts-types/index';
-import { TableCustomSortFunctionsService } from './table-custom-sort-functions.service';
+import { SortService } from './sort.service';
 
 describe('TableCustomSortFunctionsService', () => {
-  let service: TableCustomSortFunctionsService;
+  let service: SortService;
 
   const mockUrgencyA: { urgency: TranscriptionUrgency } = {
     urgency: {
@@ -24,7 +23,7 @@ describe('TableCustomSortFunctionsService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(TableCustomSortFunctionsService);
+    service = TestBed.inject(SortService);
   });
 
   it('should be created', () => {

--- a/src/app/services/sort/sort.service.ts
+++ b/src/app/services/sort/sort.service.ts
@@ -5,7 +5,7 @@ import { TranscriptionUrgency } from '@darts-types/transcription-urgency.interfa
 @Injectable({
   providedIn: 'root',
 })
-export class TableCustomSortFunctionsService {
+export class SortService {
   // only works for transcription data table
   sortByUrgencyPriorityOrder(a: unknown, b: unknown, direction?: Order) {
     const urgencyA = a as { urgency: TranscriptionUrgency };

--- a/src/app/types/user-transcription-request.interface.ts
+++ b/src/app/types/user-transcription-request.interface.ts
@@ -1,3 +1,4 @@
+import { TranscriptionUrgency } from './transcription-urgency.interface';
 import { TranscriptStatus } from './transcripts-row.interface';
 
 export interface UserTranscriptionRequest {
@@ -12,7 +13,14 @@ export interface UserTranscriptionRequest {
   requested_ts: string;
 }
 
+export type UserTranscriptionRequestVm = Omit<UserTranscriptionRequest, 'urgency'> & { urgency: TranscriptionUrgency };
+
 export interface YourTranscriptionRequests {
   requester_transcriptions: UserTranscriptionRequest[];
   approver_transcriptions: UserTranscriptionRequest[];
+}
+
+export interface YourTranscriptionRequestsVm {
+  requester_transcriptions: UserTranscriptionRequestVm[];
+  approver_transcriptions: UserTranscriptionRequestVm[];
 }

--- a/src/app/types/work-request.interface.ts
+++ b/src/app/types/work-request.interface.ts
@@ -1,3 +1,4 @@
+import { TranscriptionUrgency } from './transcription-urgency.interface';
 import { TranscriptStatus } from './transcripts-row.interface';
 
 export interface WorkRequest {
@@ -14,4 +15,4 @@ export interface WorkRequest {
   is_manual: boolean;
 }
 
-export interface WorkRequests extends Array<WorkRequest> {}
+export type WorkRequestVm = Omit<WorkRequest, 'urgency'> & { urgency: TranscriptionUrgency };


### PR DESCRIPTION
### Jira link (if applicable)

[1746](https://tools.hmcts.net/jira/browse/DMP-1746)

### Change description ###

- Move urgency mapping to the service layer to be re-usable
- Add urgency sorting to required tables
- Decoupled DTO interface from VM where needed
- Rename `TableCustomSortFunctionsService` to `SortService`
- Return a default urgency if one can't be found
- Fix tests