### PR TITLE
DMP-1773 B2C login errors

### DIFF
--- a/server/assets/javascripts/errors.js
+++ b/server/assets/javascripts/errors.js
@@ -16,9 +16,9 @@ function hideEmailPasswordErrors(delayMs = 0) {
           $(this).css('display', 'none');
         }
       });
+      $(document).off('click keydown', hideRequiredErrorsOnLoad);
+      $('#email,#password').off('input', hideRequiredErrorsOnLoad);
     }
-    $(document).off('click keydown', hideRequiredErrorsOnLoad);
-    $('#email,#password').off('input', hideRequiredErrorsOnLoad);
   }, delayMs);
 }
 


### PR DESCRIPTION
DMP-1773 

Only off click/keydown/input event if email/password contains values to allow actions like autocomplete to not fire early on the click