### PR TITLE
DMP-1406 Case Retention

### DIFF
--- a/cypress/e2e/functional/case-file-spec.cy.js
+++ b/cypress/e2e/functional/case-file-spec.cy.js
@@ -89,7 +89,7 @@ describe('Case file screen', () => {
       cy.contains('C20220620001').click();
 
       cy.get('h3.govuk-heading-s').should('contain', 'Retained until');
-      cy.get('p.govuk-body').should('contain', '10 Aug 2023');
+      cy.get('p.govuk-body').should('contain', '10 Aug 2030');
       cy.get('a.govuk-link').should('contain', 'View or change');
     });
 

--- a/cypress/e2e/functional/case-retention-spec.cy.js
+++ b/cypress/e2e/functional/case-retention-spec.cy.js
@@ -1,0 +1,71 @@
+import 'cypress-axe';
+import './commands';
+
+describe('Case retention screen', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.injectAxe();
+  });
+
+  describe('Closed case retention screen', () => {
+    beforeEach(() => {
+      cy.contains('Search').click();
+      cy.get('#case_number').type('C20220620001');
+      cy.get('button').contains('Search').click();
+      cy.contains('C20220620001').click();
+      cy.contains('View or change').click();
+    });
+
+    it('Check page elements', () => {
+      //Breadcrumb
+      cy.get('a.govuk-breadcrumbs__link').should('contain', 'Case retention date');
+      cy.get('h1.govuk-heading-l').should('contain', 'Case retention date');
+      cy.get('.govuk-table__caption.govuk-table__caption--m').should('contain', 'Case details');
+      cy.get('.govuk-table__caption.govuk-table__caption--m').should('contain', 'Current retention details');
+
+      cy.get('td.govuk-table__cell').should('contain', '15 Aug 2023');
+
+      cy.get('th.govuk-table__header').should('contain', 'Retain case until');
+
+      //Button group, only shows on closed cases
+      cy.get('.govuk-button-group').should('contain', 'Change retention date');
+      cy.get('a.govuk-link').should('contain', 'Cancel');
+
+      cy.get('#retentionTable').should('contain', '11 Oct 2023 00:18:00');
+      cy.a11y();
+    });
+  });
+
+  describe('Open case retention screen', () => {
+    beforeEach(() => {
+      cy.contains('Search').click();
+      cy.get('#case_number').type('C20220620002');
+      cy.get('button').contains('Search').click();
+      cy.contains('C20220620002').click();
+      cy.contains('View or change').click();
+    });
+
+    it('Check page elements', () => {
+      //Breadcrumb
+      cy.get('a.govuk-breadcrumbs__link').should('contain', 'Case retention date');
+
+      //Info banner, shows on open or pending cases
+      cy.get('div.govuk-notification-banner').should('contain', 'This case is still open or was recently closed.');
+
+      cy.get('h1.govuk-heading-l').should('contain', 'Case retention date');
+      cy.get('.govuk-table__caption.govuk-table__caption--m').should('contain', 'Case details');
+      cy.get('.govuk-table__caption.govuk-table__caption--m').should('contain', 'Current retention details');
+
+      cy.get('td.govuk-table__cell').should('contain', '-');
+
+      cy.get('td.govuk-table__cell').should('contain', 'A retention policy has yet to be applied to this case.');
+
+      cy.get('p.govuk-body').should('contain', 'No history to show');
+
+      //Button group, should not be visible on open cases
+      cy.get('.govuk-button-group').should('not.exist');
+
+      cy.a11y();
+    });
+  });
+});

--- a/darts-api-stub/cases/case.js
+++ b/darts-api-stub/cases/case.js
@@ -27,10 +27,6 @@ const singleCaseTwo = {
   judges: ['Judge Judy'],
   prosecutors: ['Patrick Prosecutor'],
   defenders: ['Derek Defender'],
-  retain_until_date_time: '2030-08-10T11:23:24.858Z',
-  case_closed_date_time: '2023-08-15T14:57:24.858Z',
-  retention_date_time_applied: '2023-12-12T11:02:24.858Z',
-  retention_policy_applied: 'Manual',
 };
 
 const singleCaseHearings = [

--- a/darts-api-stub/cases/case.js
+++ b/darts-api-stub/cases/case.js
@@ -12,7 +12,10 @@ const singleCase = {
   prosecutors: ['Polly Prosecutor'],
   defenders: ['Derek Defender'],
   reporting_restriction: ['Section 4(2) of the Contempt of Court Act 1981'],
-  retain_until: '2023-08-10T11:23:24.858Z',
+  retain_until_date_time: '2030-08-10T11:23:24.858Z',
+  case_closed_date_time: '2023-08-15T14:57:24.858Z',
+  retention_date_time_applied: '2023-12-12T11:02:24.858Z',
+  retention_policy_applied: 'Manual',
 };
 
 //CASES Mock objects
@@ -24,7 +27,10 @@ const singleCaseTwo = {
   judges: ['Judge Judy'],
   prosecutors: ['Patrick Prosecutor'],
   defenders: ['Derek Defender'],
-  retain_until: '',
+  retain_until_date_time: '2030-08-10T11:23:24.858Z',
+  case_closed_date_time: '2023-08-15T14:57:24.858Z',
+  retention_date_time_applied: '2023-12-12T11:02:24.858Z',
+  retention_policy_applied: 'Manual',
 };
 
 const singleCaseHearings = [

--- a/darts-api-stub/index.js
+++ b/darts-api-stub/index.js
@@ -24,6 +24,8 @@ app.use('/external-user', require('./authentication'));
 app.use('/internal-user', require('./authentication'));
 // stub out courthouses api
 app.use('/courthouses', require('./courthouses/courthouses'));
+// retention APIs
+app.use('/retentions', require('./retentions/retention'));
 // stub out certain case APIs
 app.use('/cases', require('./cases/case'));
 // audio request API

--- a/darts-api-stub/retentions/retention.js
+++ b/darts-api-stub/retentions/retention.js
@@ -22,7 +22,11 @@ const retentionHistory = [
 ];
 
 router.get('', (req, res) => {
-  res.send(retentionHistory);
+  if (req.query.case_id === '1') {
+    res.send(retentionHistory);
+  } else {
+    res.send([]);
+  }
 });
 
 module.exports = router;

--- a/darts-api-stub/retentions/retention.js
+++ b/darts-api-stub/retentions/retention.js
@@ -1,0 +1,28 @@
+const express = require('express');
+
+const router = express.Router();
+
+const retentionHistory = [
+  {
+    retention_last_changed_date: '2023-10-11T00:18:00Z',
+    retention_date: '2030-09-15',
+    amended_by: 'Judge Phil',
+    retention_policy_applied: 'Permanent',
+    comments: 'Permanent policy applied',
+    status: 'PENDING',
+  },
+  {
+    retention_last_changed_date: '2023-10-12T00:15:00Z',
+    retention_date: '2030-09-15',
+    amended_by: 'Judge Samuel',
+    retention_policy_applied: 'Manual',
+    comments: 'Manual policy applied',
+    status: 'COMPLETE',
+  },
+];
+
+router.get('', (req, res) => {
+  res.send(retentionHistory);
+});
+
+module.exports = router;

--- a/darts-api-stub/retentions/retention.js
+++ b/darts-api-stub/retentions/retention.js
@@ -19,6 +19,14 @@ const retentionHistory = [
     comments: 'Manual policy applied',
     status: 'COMPLETE',
   },
+  {
+    retention_last_changed_date: '2024-01-13T12:15:00Z',
+    retention_date: '2030-09-15',
+    amended_by: 'Judge Samuel',
+    retention_policy_applied: 'Manual',
+    comments: 'Manual policy applied',
+    status: 'COMPLETE',
+  },
 ];
 
 router.get('', (req, res) => {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -77,6 +77,14 @@ const protectedRoutes: Routes = [
     loadComponent: () => import('./components/case/case.component').then((c) => c.CaseComponent),
   },
   {
+    path: 'case/:caseId/retention',
+    data: { allowedRoles: ['APPROVER', 'REQUESTER', 'JUDGE', 'ADMIN'] },
+    loadComponent: () =>
+      import('./components/case/case-retention-date/case-retention-date.component').then(
+        (c) => c.CaseRetentionDateComponent
+      ),
+  },
+  {
     path: 'case/:caseId/hearing/:hearing_id',
     loadComponent: () => import('./components/hearing/hearing.component').then((c) => c.HearingComponent),
   },

--- a/src/app/components/case/case-file/case-file.component.html
+++ b/src/app/components/case/case-file/case-file.component.html
@@ -16,7 +16,7 @@
 @if (userService.isRequester() || userService.isApprover() || userService.isJudge() || userService.isAdmin()) {
   <h3 class="govuk-heading-s">Retained until</h3>
   <p class="govuk-body">
-    @if (caseFile.retain_until_date_time && caseFile.retain_until_date_time !== '') {
+    @if (caseFile.retain_until_date_time) {
       {{ caseFile.retain_until_date_time | date: 'd MMM y' }}
     } @else {
       No date applied

--- a/src/app/components/case/case-file/case-file.component.html
+++ b/src/app/components/case/case-file/case-file.component.html
@@ -16,8 +16,8 @@
 @if (userService.isRequester() || userService.isApprover() || userService.isJudge() || userService.isAdmin()) {
   <h3 class="govuk-heading-s">Retained until</h3>
   <p class="govuk-body">
-    @if (caseFile.retain_until && caseFile.retain_until !== '') {
-      {{ caseFile.retain_until | date: 'd MMM y' }}
+    @if (caseFile.retain_until_date_time && caseFile.retain_until_date_time !== '') {
+      {{ caseFile.retain_until_date_time | date: 'd MMM y' }}
     } @else {
       No date applied
     }

--- a/src/app/components/case/case-file/case-file.component.html
+++ b/src/app/components/case/case-file/case-file.component.html
@@ -15,5 +15,7 @@
 <h3 class="govuk-heading-s">Retained until</h3>
 <p class="govuk-body">
   {{ caseFile.retain_until | date: 'd MMM y' }} &nbsp;&nbsp;
-  <a *ngIf="caseFile.retain_until" routerLink="#" routerLinkActive="router-link-active" class="govuk-link">Change</a>
+  <a *ngIf="caseFile.retain_until" routerLink="retention" routerLinkActive="router-link-active" class="govuk-link"
+    >Change</a
+  >
 </p>

--- a/src/app/components/case/case-file/case-file.component.spec.ts
+++ b/src/app/components/case/case-file/case-file.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
 import { CaseFile } from '@darts-types/index';
 import { UserService } from '@services/user/user.service';
 import { CaseFileComponent } from './case-file.component';
@@ -18,13 +19,22 @@ describe('CaseFileComponent', () => {
     reporting_restriction: 'Section 4(2) of the Contempt of Court Act 1981',
     retain_until: '2023-08-10T11:23:24.858Z',
   };
-
+  const mockActivatedRoute = {
+    snapshot: {
+      params: {
+        caseId: 1,
+      },
+    },
+  };
   const fakeUserService = { isRequester: () => true, isTranscriber: () => false } as Partial<UserService>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [CaseFileComponent],
-      providers: [{ provide: UserService, useValue: fakeUserService }],
+      providers: [
+        { provide: UserService, useValue: fakeUserService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+      ],
     });
     fixture = TestBed.createComponent(CaseFileComponent);
     component = fixture.componentInstance;

--- a/src/app/components/case/case-file/case-file.component.ts
+++ b/src/app/components/case/case-file/case-file.component.ts
@@ -1,13 +1,14 @@
-import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Case } from '@darts-types/index';
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { ReportingRestrictionComponent } from '@common/reporting-restriction/reporting-restriction.component';
+import { Case } from '@darts-types/index';
 import { JoinPipe } from '@pipes/join';
 
 @Component({
   selector: 'app-case-file',
   standalone: true,
-  imports: [CommonModule, JoinPipe, ReportingRestrictionComponent],
+  imports: [CommonModule, JoinPipe, ReportingRestrictionComponent, RouterLink],
   templateUrl: './case-file.component.html',
   styleUrls: ['./case-file.component.scss'],
 })

--- a/src/app/components/case/case-retention-date/case-retention-date.component.html
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.html
@@ -8,36 +8,48 @@
   </app-breadcrumb>
 
   <!-- TODO: Move banner into it's own component -->
-  <div
-    class="govuk-notification-banner"
-    aria-labelledby="govuk-notification-banner-title"
-    data-module="govuk-notification-banner"
-  >
-    <div class="govuk-notification-banner__header">
-      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+  @if (!infoBannerHide(vm.retentionHistory)) {
+    <div
+      class="govuk-notification-banner"
+      aria-labelledby="govuk-notification-banner-title"
+      data-module="govuk-notification-banner"
+    >
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">This case is still open or was recently closed.</p>
+        <p class="govuk-notification-banner__body">
+          The retention date for this case cannot be changed while the case is open or while a retention policy is
+          currently pending.
+        </p>
+      </div>
     </div>
-    <div class="govuk-notification-banner__content">
-      <p class="govuk-notification-banner__heading">This case is still open or was recently closed.</p>
-      <p class="govuk-notification-banner__body">
-        The retention date for this case cannot be changed while the case is open or while a retention policy is
-        currently pending.
-      </p>
-    </div>
-  </div>
+  }
 
   <app-govuk-heading>Case retention date</app-govuk-heading>
 
   <app-details-table title="Case details" [details]="vm.caseDetails.details"></app-details-table>
 
   <ng-container>
-    <app-details-table
-      title="Current retention details"
-      [details]="{ '': 'A retention policy has yet to be applied to this case.' }"
-    ></app-details-table>
-    <div class="govuk-button-group">
-      <button class="govuk-button" data-module="govuk-button">Change retention date</button>
-      <a routerLink="../" routerLinkActive="router-link-active" class="govuk-link">Cancel</a>
-    </div>
+    @if (!vm.caseDetails.currentRetention['Date applied']) {
+      <app-details-table
+        title="Current retention details"
+        [details]="{ '': 'A retention policy has yet to be applied to this case.' }"
+      ></app-details-table>
+    } @else {
+      <app-details-table
+        title="Current retention details"
+        [details]="vm.caseDetails.currentRetention"
+      ></app-details-table>
+    }
+
+    @if (!buttonGroupHide(vm.retentionHistory)) {
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button">Change retention date</button>
+        <a routerLink="../" routerLinkActive="router-link-active" class="govuk-link">Cancel</a>
+      </div>
+    }
   </ng-container>
 
   <ng-container>
@@ -50,8 +62,8 @@
       [rows]="vm.retentionHistory"
     >
       <ng-template [tableRowTemplate]="vm.retentionHistory" let-row>
-        <td class="govuk-table__cell">{{ row.retention_last_changed_date }}</td>
-        <td class="govuk-table__cell">{{ row.retention_date }}</td>
+        <td class="govuk-table__cell">{{ row.retention_last_changed_date | date: 'dd MMM yyyy HH:mm:ss' }}</td>
+        <td class="govuk-table__cell">{{ row.retention_date | date: 'dd MMM yyyy' }}</td>
         <td class="govuk-table__cell">{{ row.amended_by }}</td>
         <td class="govuk-table__cell">{{ row.retention_policy_applied }}</td>
         <td class="govuk-table__cell">{{ row.comments }}</td>
@@ -62,8 +74,7 @@
               class="govuk-tag"
               [ngClass]="{
                 'govuk-tag--green': row.status === 'COMPLETE',
-                'govuk-tag--yellow': row.status === 'PENDING',
-                'govuk-tag--red': row.status === 'CLOSED'
+                'govuk-tag--yellow': row.status === 'PENDING'
               }"
             >
               {{ row.status }}

--- a/src/app/components/case/case-retention-date/case-retention-date.component.html
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.html
@@ -7,24 +7,12 @@
     <ng-container *breadcrumb>Case retention date</ng-container>
   </app-breadcrumb>
 
-  <!-- TODO: Move banner into it's own component -->
   @if (!infoBannerHide(vm.retentionHistory)) {
-    <div
-      class="govuk-notification-banner"
-      aria-labelledby="govuk-notification-banner-title"
-      data-module="govuk-notification-banner"
-    >
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">This case is still open or was recently closed.</p>
-        <p class="govuk-notification-banner__body">
-          The retention date for this case cannot be changed while the case is open or while a retention policy is
-          currently pending.
-        </p>
-      </div>
-    </div>
+    <app-notification-banner
+      heading="This case is still open or was recently closed."
+      body="The retention date for this case cannot be changed while the case is open or while a retention policy is
+    currently pending."
+    ></app-notification-banner>
   }
 
   <app-govuk-heading>Case retention date</app-govuk-heading>

--- a/src/app/components/case/case-retention-date/case-retention-date.component.html
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.html
@@ -36,7 +36,7 @@
     ></app-details-table>
     <div class="govuk-button-group">
       <button class="govuk-button" data-module="govuk-button">Change retention date</button>
-      <a class="govuk-link" routerLink="../" routerLinkActive="router-link-active">Cancel</a>
+      <a routerLink="../" routerLinkActive="router-link-active" class="govuk-link">Cancel</a>
     </div>
   </ng-container>
 
@@ -48,7 +48,30 @@
       noDataMessage="No history to show"
       [columns]="columns"
       [rows]="vm.retentionHistory"
-    ></app-data-table>
+    >
+      <ng-template [tableRowTemplate]="vm.retentionHistory" let-row>
+        <td class="govuk-table__cell">{{ row.retention_last_changed_date }}</td>
+        <td class="govuk-table__cell">{{ row.retention_date }}</td>
+        <td class="govuk-table__cell">{{ row.amended_by }}</td>
+        <td class="govuk-table__cell">{{ row.retention_policy_applied }}</td>
+        <td class="govuk-table__cell">{{ row.comments }}</td>
+
+        <td class="govuk-table__cell">
+          <div class="status-cell">
+            <strong
+              class="govuk-tag"
+              [ngClass]="{
+                'govuk-tag--green': row.status === 'COMPLETE',
+                'govuk-tag--yellow': row.status === 'PENDING',
+                'govuk-tag--red': row.status === 'CLOSED'
+              }"
+            >
+              {{ row.status }}
+            </strong>
+          </div>
+        </td>
+      </ng-template>
+    </app-data-table>
   </ng-container>
 } @else {
   <ng-template #loading>

--- a/src/app/components/case/case-retention-date/case-retention-date.component.html
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.html
@@ -1,0 +1,57 @@
+@if (vm$ | async; as vm) {
+  <app-breadcrumb>
+    <ng-container *breadcrumb="['/search']">Search</ng-container>
+    <ng-container *breadcrumb="['/case', vm.caseDetails.case_id.toString()]">{{
+      vm.caseDetails.case_number
+    }}</ng-container>
+    <ng-container *breadcrumb>Case retention date</ng-container>
+  </app-breadcrumb>
+
+  <!-- TODO: Move banner into it's own component -->
+  <div
+    class="govuk-notification-banner"
+    aria-labelledby="govuk-notification-banner-title"
+    data-module="govuk-notification-banner"
+  >
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">This case is still open or was recently closed.</p>
+      <p class="govuk-notification-banner__body">
+        The retention date for this case cannot be changed while the case is open or while a retention policy is
+        currently pending.
+      </p>
+    </div>
+  </div>
+
+  <app-govuk-heading>Case retention date</app-govuk-heading>
+
+  <app-details-table title="Case details" [details]="vm.caseDetails.details"></app-details-table>
+
+  <ng-container>
+    <app-details-table
+      title="Current retention details"
+      [details]="{ '': 'A retention policy has yet to be applied to this case.' }"
+    ></app-details-table>
+    <div class="govuk-button-group">
+      <button class="govuk-button" data-module="govuk-button">Change retention date</button>
+      <a class="govuk-link" routerLink="../" routerLinkActive="router-link-active">Cancel</a>
+    </div>
+  </ng-container>
+
+  <ng-container>
+    <h2 class="govuk-heading-m">Retention audit history</h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+    <app-data-table
+      id="retentionTable"
+      noDataMessage="No history to show"
+      [columns]="columns"
+      [rows]="vm.retentionHistory"
+    ></app-data-table>
+  </ng-container>
+} @else {
+  <ng-template #loading>
+    <app-loading text="Loading case retention details..."></app-loading>
+  </ng-template>
+}

--- a/src/app/components/case/case-retention-date/case-retention-date.component.scss
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.scss
@@ -1,0 +1,8 @@
+.govuk-notification-banner {
+  margin-top: 50px;
+}
+
+.govuk-button-group {
+  margin-top: 50px;
+  margin-bottom: 50px;
+}

--- a/src/app/components/case/case-retention-date/case-retention-date.component.scss
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.scss
@@ -1,7 +1,3 @@
-.govuk-notification-banner {
-  margin-top: 50px;
-}
-
 .govuk-button-group {
   margin-top: 50px;
   margin-bottom: 50px;

--- a/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CaseRetentionDateComponent } from './case-retention-date.component';
+
+describe('CaseRetentionDateComponent', () => {
+  let component: CaseRetentionDateComponent;
+  let fixture: ComponentFixture<CaseRetentionDateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CaseRetentionDateComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CaseRetentionDateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
@@ -3,6 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
+import { CaseRetentionHistory } from '@darts-types/case-retention-history.interface';
+import { Case } from '@darts-types/case.interface';
+import { CaseService } from '@services/case/case.service';
+import { of } from 'rxjs';
 import { CaseRetentionDateComponent } from './case-retention-date.component';
 
 describe('CaseRetentionDateComponent', () => {
@@ -17,10 +21,61 @@ describe('CaseRetentionDateComponent', () => {
     },
   };
 
+  const mockRetentionHistory: CaseRetentionHistory[] = [
+    {
+      retention_last_changed_date: '2023-01-01T00:00:00Z',
+      retention_date: '2030-09-15',
+      amended_by: 'Judge Phil',
+      retention_policy_applied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'COMPLETE',
+    },
+    {
+      retention_last_changed_date: '2023-01-03T00:00:00Z',
+      retention_date: '2030-09-15',
+      amended_by: 'Judge Phil',
+      retention_policy_applied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'PENDING',
+    },
+    {
+      retention_last_changed_date: '2023-01-02T00:00:00Z',
+      retention_date: '2030-09-15',
+      amended_by: 'Judge Phil',
+      retention_policy_applied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'PENDING',
+    },
+  ];
+
+  const mockCaseData: Case = {
+    case_id: 1,
+    courthouse: 'Swansea',
+    case_number: 'C20220620001',
+    defendants: ['Defendant Dave'],
+    judges: ['Judge Judy'],
+    prosecutors: ['Polly Prosecutor'],
+    defenders: ['Derek Defender'],
+    retain_until_date_time: '2030-08-10T11:23:24.858Z',
+    case_closed_date_time: '2023-08-15T14:57:24.858Z',
+    retention_date_time_applied: '2023-12-12T11:02:24.858Z',
+    retention_policy_applied: 'Manual',
+  };
+
+  const mockCaseService = {
+    getCase: () => of(mockCaseData),
+    getCaseRetentionHistory: jest.fn(),
+  } as unknown as CaseService;
+  const mockDatePipe = new DatePipe('en-GB');
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CaseRetentionDateComponent, HttpClientTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }, { provide: DatePipe }],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: DatePipe },
+        { provide: CaseService, useValue: mockCaseService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CaseRetentionDateComponent);
@@ -30,5 +85,69 @@ describe('CaseRetentionDateComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('#getLatestDate', () => {
+    const result = component.getLatestDate(mockRetentionHistory);
+
+    expect(result).toEqual(mockRetentionHistory[1]);
+  });
+
+  describe('#infoBannerHide', () => {
+    it('should return false if rows array is empty', () => {
+      expect(component.infoBannerHide([])).toBe(false);
+    });
+
+    it('should return true if the latest date status is not PENDING', () => {
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[0]);
+      expect(component.infoBannerHide(mockRetentionHistory)).toBe(true);
+    });
+
+    it('should return false if the latest date status is PENDING', () => {
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[1]);
+      expect(component.infoBannerHide(mockRetentionHistory)).toBe(false);
+    });
+  });
+
+  describe('#buttonGroupHide', () => {
+    it('should return true if rows array is empty', () => {
+      expect(component.buttonGroupHide([])).toBe(true);
+    });
+
+    it('should return true if the latest date status is not COMPLETE', () => {
+      const mockLatestDate = mockRetentionHistory[2];
+      expect(mockLatestDate.status).not.toBe('COMPLETE');
+
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockLatestDate);
+
+      const result = component.buttonGroupHide(mockRetentionHistory);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the latest date status is COMPLETE', () => {
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[0]);
+      expect(component.buttonGroupHide(mockRetentionHistory)).toBe(false);
+    });
+  });
+
+  it('should transform case details correctly', (done) => {
+    component.caseDetails$.subscribe((caseDetails) => {
+      expect(caseDetails.details).toEqual({
+        'Case ID': 1,
+        'Case closed date': mockDatePipe.transform(mockCaseData.case_closed_date_time, 'dd MMM yyyy') || '-',
+        Courthouse: 'Swansea',
+        'Judge(s)': ['Judge Judy'],
+        'Defendant(s)': ['Defendant Dave'],
+      });
+
+      expect(caseDetails.currentRetention).toEqual({
+        'Date applied': mockDatePipe.transform(mockCaseData.retention_date_time_applied, 'dd MMM yyyy'),
+        'Retain case until': mockDatePipe.transform(mockCaseData.retain_until_date_time, 'dd MMM yyyy'),
+        'DARTS Retention policy applied': 'Manual',
+      });
+      expect(caseDetails.case_id).toBe(1);
+      expect(caseDetails.case_number).toBe('C20220620001');
+      done();
+    });
   });
 });

--- a/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.spec.ts
@@ -1,17 +1,28 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { DatePipe } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
 import { CaseRetentionDateComponent } from './case-retention-date.component';
 
 describe('CaseRetentionDateComponent', () => {
   let component: CaseRetentionDateComponent;
   let fixture: ComponentFixture<CaseRetentionDateComponent>;
 
+  const mockActivatedRoute = {
+    snapshot: {
+      params: {
+        caseId: 1,
+      },
+    },
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CaseRetentionDateComponent]
-    })
-    .compileComponents();
-    
+      imports: [CaseRetentionDateComponent, HttpClientTestingModule],
+      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }, { provide: DatePipe }],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(CaseRetentionDateComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/components/case/case-retention-date/case-retention-date.component.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.ts
@@ -1,0 +1,74 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Case } from '@darts-types/case.interface';
+import { DatatableColumn } from '@darts-types/data-table-column.interface';
+import { BreadcrumbDirective } from '@directives/breadcrumb.directive';
+import { CaseService } from '@services/case/case.service';
+import { HeaderService } from '@services/header/header.service';
+import { combineLatest, map } from 'rxjs';
+import { BreadcrumbComponent } from '../../common/breadcrumb/breadcrumb.component';
+import { DataTableComponent } from '../../common/data-table/data-table.component';
+import { DetailsTableComponent } from '../../common/details-table/details-table.component';
+import { GovukHeadingComponent } from '../../common/govuk-heading/govuk-heading.component';
+import { LoadingComponent } from '../../common/loading/loading.component';
+
+@Component({
+  selector: 'app-case-retention-date',
+  standalone: true,
+  templateUrl: './case-retention-date.component.html',
+  styleUrl: './case-retention-date.component.scss',
+  imports: [
+    BreadcrumbComponent,
+    BreadcrumbDirective,
+    LoadingComponent,
+    CommonModule,
+    GovukHeadingComponent,
+    DetailsTableComponent,
+    DataTableComponent,
+  ],
+})
+export class CaseRetentionDateComponent implements OnInit {
+  headerService = inject(HeaderService);
+  route = inject(ActivatedRoute);
+  caseService = inject(CaseService);
+
+  caseId = this.route.snapshot.params.caseId;
+  //TODO: Map retention_last_changed_date & retention_date to display format
+  //TODO: Show status display properly
+  retentionHistory$ = this.caseService.getCaseRetentionHistory(this.caseId);
+  caseDetails$ = this.caseService.getCase(this.caseId).pipe(
+    map((data: Case) => {
+      const caseDetails = {
+        details: {
+          'Case ID': data.case_id,
+          'Case closed date': '-TO-DO------',
+          Courthouse: data.courthouse,
+          'Judge(s)': data.judges,
+          'Defendant(s)': data.defendants,
+        },
+        case_id: data.case_id,
+        case_number: data.case_number,
+      };
+      return caseDetails;
+    })
+  );
+
+  vm$ = combineLatest({
+    caseDetails: this.caseDetails$,
+    retentionHistory: this.retentionHistory$,
+  });
+
+  columns: DatatableColumn[] = [
+    { name: 'Date retention changed', prop: 'retention_last_changed_date', sortable: true },
+    { name: 'Retention date', prop: 'retention_date', sortable: false },
+    { name: 'Amended by', prop: 'amended_by', sortable: false },
+    { name: 'Retention policy', prop: 'retention_policy_applied', sortable: false },
+    { name: 'Comments', prop: 'comments', sortable: false },
+    { name: 'Status', prop: 'status', sortable: false },
+  ];
+
+  ngOnInit(): void {
+    this.headerService.hideNavigation();
+  }
+}

--- a/src/app/components/case/case-retention-date/case-retention-date.component.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.ts
@@ -14,6 +14,7 @@ import { DataTableComponent } from '../../common/data-table/data-table.component
 import { DetailsTableComponent } from '../../common/details-table/details-table.component';
 import { GovukHeadingComponent } from '../../common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '../../common/loading/loading.component';
+import { NotificationBannerComponent } from '../../common/notification-banner/notification-banner.component';
 
 @Component({
   selector: 'app-case-retention-date',
@@ -30,6 +31,7 @@ import { LoadingComponent } from '../../common/loading/loading.component';
     DataTableComponent,
     RouterLink,
     TableRowTemplateDirective,
+    NotificationBannerComponent,
   ],
 })
 export class CaseRetentionDateComponent implements OnInit {

--- a/src/app/components/case/case-retention-date/case-retention-date.component.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.ts
@@ -77,8 +77,9 @@ export class CaseRetentionDateComponent implements OnInit {
   buttonGroupHide(rows: CaseRetentionHistory[]): boolean {
     if (rows.length) {
       return this.getLatestDate(rows).status !== 'COMPLETE';
+    } else {
+      return true;
     }
-    return true;
   }
 
   getLatestDate(rows: CaseRetentionHistory[]) {

--- a/src/app/components/common/details-table/details-table.component.html
+++ b/src/app/components/common/details-table/details-table.component.html
@@ -13,7 +13,7 @@
         </tr>
       } @else if (isNotNullUndefinedOrEmptyString(detail.value)) {
         <tr class="govuk-table__row">
-          <th class="govuk-table__header">{{ detail.key }}</th>
+          <th [id]="'detail-th-' + $index" class="govuk-table__header">{{ detail.key }}</th>
           <td class="govuk-table__cell table-width">{{ detail.value }}</td>
         </tr>
       }

--- a/src/app/components/common/details-table/details-table.component.html
+++ b/src/app/components/common/details-table/details-table.component.html
@@ -6,7 +6,12 @@
   </caption>
   <tbody class="govuk-table__body">
     @for (detail of details | keyvalue: originalOrder; track $index) {
-      @if (isNotNullUndefinedOrEmptyString(detail.value)) {
+      @if (isNotNullUndefinedOrEmptyString(detail.value) && !isNotNullUndefinedOrEmptyString(detail.key)) {
+        <!-- Single column message -->
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell table-width">{{ detail.value }}</td>
+        </tr>
+      } @else if (isNotNullUndefinedOrEmptyString(detail.value)) {
         <tr class="govuk-table__row">
           <th class="govuk-table__header">{{ detail.key }}</th>
           <td class="govuk-table__cell table-width">{{ detail.value }}</td>

--- a/src/app/components/common/notification-banner/notification-banner.component.html
+++ b/src/app/components/common/notification-banner/notification-banner.component.html
@@ -1,0 +1,15 @@
+<div
+  class="govuk-notification-banner"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner"
+>
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">{{ heading }}</p>
+    <p class="govuk-notification-banner__body">
+      {{ body }}
+    </p>
+  </div>
+</div>

--- a/src/app/components/common/notification-banner/notification-banner.component.scss
+++ b/src/app/components/common/notification-banner/notification-banner.component.scss
@@ -1,0 +1,4 @@
+.govuk-notification-banner {
+  margin-top: 50px;
+  max-width: 760px;
+}

--- a/src/app/components/common/notification-banner/notification-banner.component.spec.ts
+++ b/src/app/components/common/notification-banner/notification-banner.component.spec.ts
@@ -8,10 +8,9 @@ describe('NotificationBannerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NotificationBannerComponent]
-    })
-    .compileComponents();
-    
+      imports: [NotificationBannerComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(NotificationBannerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/components/common/notification-banner/notification-banner.component.spec.ts
+++ b/src/app/components/common/notification-banner/notification-banner.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationBannerComponent } from './notification-banner.component';
+
+describe('NotificationBannerComponent', () => {
+  let component: NotificationBannerComponent;
+  let fixture: ComponentFixture<NotificationBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotificationBannerComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(NotificationBannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/common/notification-banner/notification-banner.component.ts
+++ b/src/app/components/common/notification-banner/notification-banner.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-notification-banner',
+  standalone: true,
+  imports: [],
+  templateUrl: './notification-banner.component.html',
+  styleUrl: './notification-banner.component.scss',
+})
+export class NotificationBannerComponent {
+  @Input() heading = '';
+  @Input() body = '';
+}

--- a/src/app/components/hearing/request-transcript/request-transcript-confirmation/request-transcript-confirmation.component.html
+++ b/src/app/components/hearing/request-transcript/request-transcript-confirmation/request-transcript-confirmation.component.html
@@ -2,7 +2,7 @@
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-table__caption--m">
-    Case Details
+    Case details
   </caption>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
@@ -22,7 +22,7 @@
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-table__caption--m">
-    Request Details
+    Request details
   </caption>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">

--- a/src/app/components/transcriptions/view-transcript/view-transcript.component.html
+++ b/src/app/components/transcriptions/view-transcript/view-transcript.component.html
@@ -2,7 +2,7 @@
   <ng-template #caseDetailsTable>
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">
-        Case Details
+        Case details
       </caption>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
@@ -78,7 +78,7 @@
 
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">
-        Request Details
+        Request details
       </caption>
       <tbody class="govuk-table__body">
         <ng-container *ngTemplateOutlet="requestDetailsPartial"></ng-container>

--- a/src/app/services/case/case.service.ts
+++ b/src/app/services/case/case.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { CaseRetentionHistory } from '@darts-types/case-retention-history.interface';
 import { Case, Courthouse, Hearing, SearchFormValues, Transcript } from '@darts-types/index';
 import { Observable, of } from 'rxjs';
 import { catchError, map, shareReplay } from 'rxjs/operators';
@@ -8,6 +9,7 @@ export const GET_COURTHOUSES_PATH = '/api/courthouses';
 export const GET_CASE_PATH = '/api/cases';
 export const GET_HEARINGS_PATH = 'api/hearings';
 export const ADVANCED_SEARCH_CASE_PATH = '/api/cases/search';
+export const GET_CASE_RETENTION_HISTORY = '/api/retentions';
 
 @Injectable({
   providedIn: 'root',
@@ -100,5 +102,17 @@ export class CaseService {
    */
   getHearingById(cId: number, hId: number): Observable<Hearing | undefined> {
     return this.getCaseHearings(cId).pipe(map((h) => h.find((x) => x.id == hId)));
+  }
+
+  getCaseRetentionHistory(caseId: number): Observable<CaseRetentionHistory[]> {
+    let params = new HttpParams();
+    params = params.set('case_id', caseId);
+    return this.http.get<CaseRetentionHistory[]>(GET_CASE_RETENTION_HISTORY, { params }).pipe(
+      //TODO: Add Z stamp to 'retention_date'
+      //
+      catchError(() => {
+        return of([]);
+      })
+    );
   }
 }

--- a/src/app/services/case/case.service.ts
+++ b/src/app/services/case/case.service.ts
@@ -108,8 +108,7 @@ export class CaseService {
     let params = new HttpParams();
     params = params.set('case_id', caseId);
     return this.http.get<CaseRetentionHistory[]>(GET_CASE_RETENTION_HISTORY, { params }).pipe(
-      //TODO: Add Z stamp to 'retention_date'
-      //
+      map((hearings) => hearings.map((h) => ({ ...h, retention_date: h.retention_date + 'T00:00:00Z' }))),
       catchError(() => {
         return of([]);
       })

--- a/src/app/types/case-retention-history.interface.ts
+++ b/src/app/types/case-retention-history.interface.ts
@@ -1,0 +1,8 @@
+export interface CaseRetentionHistory {
+  retention_last_changed_date: string;
+  retention_date: string;
+  amended_by: string;
+  retention_policy_applied: string;
+  comments: string;
+  status: string;
+}

--- a/src/app/types/case.interface.ts
+++ b/src/app/types/case.interface.ts
@@ -11,4 +11,8 @@ export interface Case {
   hearings?: Hearing[];
   retain_until?: string;
   prosecutors?: string[];
+  retain_until_date_time?: string;
+  case_closed_date_time?: string;
+  retention_date_time_applied?: string;
+  retention_policy_applied?: string;
 }


### PR DESCRIPTION
DMP-1406

- New case retention screen
- Notification banner into own component
- Updated stubs for GET /cases/{id} endpoint, and new GET /retentions?id=1
- Unit tests / FT 

To test;

See /case/1 & /case/2 for same page, different visible elements. 

Logic is;
Info banner: "if that array is empty OR latest record is PENDING then show banner, else hide it"
Button group: "if latest record is COMPLETE then show button group, else hide it"


- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
