### PR TITLE
DMP-2051 Ignore Audio count API errors

### DIFF
--- a/src/app/services/error/error-message.service.spec.ts
+++ b/src/app/services/error/error-message.service.spec.ts
@@ -19,7 +19,7 @@ describe('ErrorMessageService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('Subscribed endpoint error handling', () => {
+  describe('Subscribed endpoints error handling', () => {
     it('should not change route on the subscribed endpoints, for transcriptions', () => {
       const error = new HttpErrorResponse({ status: 409, url: '/api/transcriptions' });
       const navigateSpy = jest.spyOn(mockRouter, 'navigateByUrl');
@@ -46,6 +46,15 @@ describe('ErrorMessageService', () => {
 
       const error2 = new HttpErrorResponse({ status: 204, url: '/api/cases/search' });
       service.handleErrorMessage(error2);
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Ignored endpoints error handling', () => {
+    it('should not change route on the ignored endpoints, for not-accessed-count', () => {
+      const error = new HttpErrorResponse({ status: 500, url: '/api/audio-requests/not-accessed-count' });
+      const navigateSpy = jest.spyOn(mockRouter, 'navigateByUrl');
+      service.handleErrorMessage(error);
       expect(navigateSpy).not.toHaveBeenCalled();
     });
   });

--- a/src/app/services/error/error-message.service.ts
+++ b/src/app/services/error/error-message.service.ts
@@ -14,6 +14,11 @@ const subscribedEndpoints = [
   { endpoint: '/api/audio/preview', responses: [403, 404, 500, 502, 504] },
 ];
 
+//Contains endpoints where errors will be ignored
+const ignoredEndpoints = [
+  { endpoint: '/api/audio-requests/not-accessed-count', responses: [400, 401, 403, 404, 500, 502, 504] },
+];
+
 @Injectable({
   providedIn: 'root',
 })
@@ -49,7 +54,7 @@ export class ErrorMessageService {
 
   //Used to handle other components/endpoints that do not subscribe to the error
   private handleOtherPages(error: HttpErrorResponse) {
-    if (!this.isSubscribed(error)) {
+    if (!this.isSubscribed(error) && !this.isIgnored(error)) {
       switch (error.status) {
         case 403:
           this.showForbidden();
@@ -69,6 +74,15 @@ export class ErrorMessageService {
 
   private isSubscribed(response: HttpErrorResponse) {
     return subscribedEndpoints.some((subscribed) => {
+      const endpointMatches = response.url?.includes(subscribed.endpoint);
+      const responseMatches = subscribed.responses.includes(response.status);
+
+      return endpointMatches && responseMatches;
+    });
+  }
+
+  private isIgnored(response: HttpErrorResponse) {
+    return ignoredEndpoints.some((subscribed) => {
       const endpointMatches = response.url?.includes(subscribed.endpoint);
       const responseMatches = subscribed.responses.includes(response.status);
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-2051

Created ignored endpoints array, and isIgnored function to ensure page redirect does not occur on not-accessed-count endpoint for specific responses.


- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
