### PR TITLE
DMP-1924: Data table bugfix - maintain sorting and paging state on data refresh

### DIFF
--- a/src/app/components/common/data-table/data-table.component.html
+++ b/src/app/components/common/data-table/data-table.component.html
@@ -34,7 +34,9 @@
             [attr.aria-sort]="getAriaSort(column.prop)"
             [ngStyle]="{ width: column.width }"
           >
-            <button type="button" (click)="sortTable(column.prop, column.customSortFn)">{{ column.name }}</button>
+            <button type="button" (click)="sortTable(column.prop, column.customSortFn)">
+              {{ column.name }}
+            </button>
           </th>
           <th
             *ngIf="!column.sortable && column.name"

--- a/src/app/components/common/data-table/data-table.component.spec.ts
+++ b/src/app/components/common/data-table/data-table.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DateTime } from 'luxon';
 
+import { SimpleChanges } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { Order } from '@darts-types/data-table-column.interface';
 import { Urgency } from '@darts-types/transcription-urgency.interface';
@@ -78,7 +79,7 @@ describe('DataTableComponent', () => {
       component.currentPage = 1;
       component.pageLimit = 1;
 
-      component.ngOnChanges();
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges); // Pass an empty object as an argument
 
       expect(component.pagedRows.length).toEqual(1);
     });
@@ -107,7 +108,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -126,7 +127,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -146,7 +147,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -165,7 +166,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -265,7 +266,7 @@ describe('DataTableComponent', () => {
         order: 'desc',
       };
 
-      component.sortTable(column, (a: unknown, b: unknown, direction?: Order) => {
+      const sortFn = (a: unknown, b: unknown, direction?: Order) => {
         const urgencyA = a as { urgency: Urgency };
         const urgencyB = b as { urgency: Urgency };
 
@@ -276,11 +277,13 @@ describe('DataTableComponent', () => {
         } else {
           return 0;
         }
-      });
+      };
+      component.sortTable(column, sortFn);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
+        sortFn,
       };
 
       expect(component.sorting).toEqual(expectedSorting);
@@ -378,7 +381,7 @@ describe('DataTableComponent', () => {
         order: 'asc',
       };
 
-      component.sortTable(column, (a: unknown, b: unknown, direction?: Order) => {
+      const sortFn = (a: unknown, b: unknown, direction?: Order) => {
         const urgencyA = a as { urgency: Urgency };
         const urgencyB = b as { urgency: Urgency };
 
@@ -389,11 +392,13 @@ describe('DataTableComponent', () => {
         } else {
           return 0;
         }
-      });
+      };
+      component.sortTable(column, sortFn);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
+        sortFn,
       };
 
       expect(component.sorting).toEqual(expectedSorting);
@@ -411,7 +416,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -430,7 +435,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -450,7 +455,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -469,7 +474,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -489,7 +494,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -508,7 +513,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -528,7 +533,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'asc',
       };
@@ -547,7 +552,7 @@ describe('DataTableComponent', () => {
 
       component.sortTable(column);
 
-      const expectedSorting: SortingInterface = {
+      const expectedSorting: SortingInterface<unknown> = {
         column,
         order: 'desc',
       };
@@ -672,13 +677,14 @@ describe('DataTableComponent', () => {
 
     it('should reset column sorting state on cases changed', () => {
       component.rows = MOCK_ROWS;
+      component.sortAndPaginateOnRowsChanged = false;
       const column = 'case_number';
       component.sorting = {
         column,
         order: 'asc',
       };
 
-      component.ngOnChanges();
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
 
       expect(component.sorting.column).toBe('');
     });
@@ -733,5 +739,43 @@ describe('DataTableComponent', () => {
     const noDataMessage = fixture.debugElement.query(By.css('#no-data-message'));
     expect(noDataMessage).toBeTruthy();
     expect(noDataMessage.nativeElement.textContent).toContain('No data');
+  });
+
+  describe('#sortAndPaginateOnRowsChanged', () => {
+    it('true: maintains sorting and page number when rows are updated', () => {
+      component.rows = MOCK_ROWS;
+      component.sortAndPaginateOnRowsChanged = true;
+      component.sorting = {
+        column: 'case_number',
+        order: 'asc',
+      };
+      component.currentPage = 2;
+
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+
+      expect(component.sorting).toEqual({
+        column: 'case_number',
+        order: 'asc',
+      });
+      expect(component.currentPage).toEqual(2);
+    });
+
+    it('false: resets sorting and page when rows are updated', () => {
+      component.rows = MOCK_ROWS;
+      component.sortAndPaginateOnRowsChanged = false;
+      component.sorting = {
+        column: 'case_number',
+        order: 'desc',
+      };
+      component.currentPage = 2;
+
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+
+      expect(component.sorting).toEqual({
+        column: '',
+        order: 'desc',
+      });
+      expect(component.currentPage).toEqual(1);
+    });
   });
 });

--- a/src/app/components/common/data-table/data-table.component.spec.ts
+++ b/src/app/components/common/data-table/data-table.component.spec.ts
@@ -741,41 +741,60 @@ describe('DataTableComponent', () => {
     expect(noDataMessage.nativeElement.textContent).toContain('No data');
   });
 
-  describe('#sortAndPaginateOnRowsChanged', () => {
-    it('true: maintains sorting and page number when rows are updated', () => {
+  describe('#ngOnChanges', () => {
+    it('if rows not changed, do nothing', () => {
       component.rows = MOCK_ROWS;
-      component.sortAndPaginateOnRowsChanged = true;
       component.sorting = {
         column: 'case_number',
-        order: 'asc',
+        order: 'desc',
       };
       component.currentPage = 2;
 
-      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+      component.ngOnChanges({} as unknown as SimpleChanges);
 
       expect(component.sorting).toEqual({
         column: 'case_number',
-        order: 'asc',
+        order: 'desc',
       });
       expect(component.currentPage).toEqual(2);
     });
 
-    it('false: resets sorting and page when rows are updated', () => {
-      component.rows = MOCK_ROWS;
-      component.sortAndPaginateOnRowsChanged = false;
-      component.sorting = {
-        column: 'case_number',
-        order: 'desc',
-      };
-      component.currentPage = 2;
+    describe('#sortAndPaginateOnRowsChanged', () => {
+      it('true: maintains sorting and page number when rows are updated', () => {
+        component.rows = MOCK_ROWS;
+        component.sortAndPaginateOnRowsChanged = true;
+        component.sorting = {
+          column: 'case_number',
+          order: 'asc',
+        };
+        component.currentPage = 2;
 
-      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+        component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
 
-      expect(component.sorting).toEqual({
-        column: '',
-        order: 'desc',
+        expect(component.sorting).toEqual({
+          column: 'case_number',
+          order: 'asc',
+        });
+        expect(component.currentPage).toEqual(2);
       });
-      expect(component.currentPage).toEqual(1);
+
+      it('false: resets sorting and page when rows are updated', () => {
+        component.rows = MOCK_ROWS;
+        component.sortAndPaginateOnRowsChanged = false;
+        component.sorting = {
+          column: 'case_number',
+          order: 'desc',
+        };
+        component.currentPage = 2;
+
+        component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+
+        expect(component.sorting).toEqual({
+          column: '',
+          order: 'desc',
+        });
+        expect(component.currentPage).toEqual(1);
+      });
     });
   });
 });

--- a/src/app/components/common/data-table/data-table.component.ts
+++ b/src/app/components/common/data-table/data-table.component.ts
@@ -7,6 +7,7 @@ import {
   Input,
   OnChanges,
   Output,
+  SimpleChanges,
   TemplateRef,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -33,6 +34,7 @@ export class DataTableComponent<TRow> implements OnChanges {
   @Input() pageLimit = 25;
   @Input() noDataMessage = 'No data to display.';
   @Input() checkboxKey = '';
+  @Input() sortAndPaginateOnRowsChanged = true; // To maintain the sorting and pagination when rows are changed e.g. polling updates the data
   @Output() rowSelect = new EventEmitter<TRow[]>();
 
   @ContentChild(TableBodyTemplateDirective, { read: TemplateRef })
@@ -45,15 +47,24 @@ export class DataTableComponent<TRow> implements OnChanges {
   pagedRows: TRow[] = [];
   currentPage = 1;
 
-  sorting: SortingInterface = {
+  sorting: SortingInterface<TRow> = {
     column: '',
     order: 'asc',
+    sortFn: undefined,
   };
 
-  ngOnChanges(): void {
-    this.sorting.column = '';
-    this.currentPage = 1;
-    this.updatePagedData();
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes.rows) {
+      return;
+    }
+    if (!this.sortAndPaginateOnRowsChanged) {
+      this.sorting.column = '';
+      this.currentPage = 1;
+      this.updatePagedData();
+    } else {
+      this.sorting.order = this.isDescSorting(this.sorting.column) ? 'asc' : 'desc';
+      this.sortTable(this.sorting.column, this.sorting.sortFn);
+    }
   }
 
   onPageChanged(page: number): void {
@@ -65,6 +76,7 @@ export class DataTableComponent<TRow> implements OnChanges {
     this.sorting = {
       column: column,
       order: this.isDescSorting(column) ? 'asc' : 'desc',
+      sortFn: sortFn,
     };
 
     if (sortFn) {
@@ -191,7 +203,8 @@ export class DataTableComponent<TRow> implements OnChanges {
   }
 }
 
-export interface SortingInterface {
+export interface SortingInterface<Row> {
   column: string;
   order: 'asc' | 'desc';
+  sortFn?: CustomSort<Row>;
 }

--- a/src/app/components/search/results/results.component.html
+++ b/src/app/components/search/results/results.component.html
@@ -7,7 +7,7 @@
     <p class="govuk-body">Review the case ID, case reference or court reference you entered and try again.</p>
   </div>
   <div *ngIf="cases.length">
-    <app-data-table [rows]="cases" [columns]="columns" [caption]="caption">
+    <app-data-table [rows]="cases" [columns]="columns" [caption]="caption" [sortAndPaginateOnRowsChanged]="false">
       <ng-template [tableBodyTemplate] let-row>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">

--- a/src/app/services/transcription/transcription.service.spec.ts
+++ b/src/app/services/transcription/transcription.service.spec.ts
@@ -50,10 +50,25 @@ describe('TranscriptionService', () => {
   });
 
   describe('#getUrgencies', () => {
-    it('should call the correct endpoint', () => {
-      const spy = jest.spyOn(service['http'], 'get');
-      service.getUrgencies();
-      expect(spy).toHaveBeenCalledWith('/api/transcriptions/urgencies');
+    it('call the correct endpoint and return the urgencies', (done) => {
+      service.getUrgencies().subscribe((urgencies) => {
+        expect(urgencies).toEqual(MOCK_URGENCIES);
+        done();
+      });
+
+      const req = httpMock.expectOne('/api/transcriptions/urgencies');
+      req.flush(MOCK_URGENCIES);
+    });
+
+    it('only make one call and share results to subsequent subscribers ', () => {
+      service.getUrgencies().subscribe();
+      service.getUrgencies().subscribe();
+      service.getUrgencies().subscribe();
+
+      const req = httpMock.expectOne('/api/transcriptions/urgencies');
+      req.flush(MOCK_URGENCIES);
+
+      httpMock.verify();
     });
   });
 

--- a/src/app/services/transcription/transcription.service.ts
+++ b/src/app/services/transcription/transcription.service.ts
@@ -29,8 +29,8 @@ export class TranscriptionService {
   luxonPipe = inject(LuxonDatePipe);
   http = inject(HttpClient);
   countService = inject(CountNotificationService);
-
   private readonly DATA_POLL_INTERVAL_SECS = 60;
+  private readonly urgencies$ = this.http.get<Urgency[]>('/api/transcriptions/urgencies').pipe(shareReplay(1));
 
   unassignedRequests$ = timer(0, this.DATA_POLL_INTERVAL_SECS * 1000).pipe(
     switchMap(() => this.getWorkRequests(false)),
@@ -47,7 +47,7 @@ export class TranscriptionService {
   );
 
   getUrgencies(): Observable<Urgency[]> {
-    return this.http.get<Urgency[]>('/api/transcriptions/urgencies').pipe(shareReplay(1));
+    return this.urgencies$;
   }
 
   getTranscriptionTypes(): Observable<TranscriptionType[]> {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-1924

### Change description ###

- Fixed bug as per JIRA ticket
- Urgencies are now cached in the TranscriptionService to avoid duplicate calls