### PR TITLE
DP-2188 Data table with no pagination fix

### DIFF
--- a/src/app/components/common/data-table/data-table.component.spec.ts
+++ b/src/app/components/common/data-table/data-table.component.spec.ts
@@ -94,6 +94,17 @@ describe('DataTableComponent', () => {
       expect(component.pagedRows.length).toEqual(1);
       expect(component.pagedRows[0]).toEqual(MOCK_ROWS[3]);
     });
+
+    it('does not paginate when it is disabled', () => {
+      component.rows = MOCK_ROWS;
+      component.pageLimit = 2;
+      component.pagination = false;
+
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges); // Pass an empty object as an argument
+
+      // given 4 rows and an irrelevant page limit of 2, we expect all rows to display
+      expect(component.pagedRows.length).toEqual(4);
+    });
   });
 
   describe('Sorting', () => {

--- a/src/app/components/common/data-table/data-table.component.ts
+++ b/src/app/components/common/data-table/data-table.component.ts
@@ -195,7 +195,7 @@ export class DataTableComponent<TRow> implements OnChanges {
   }
 
   private updatePagedData(): void {
-    this.pagedRows = this.paginate(this.rows, this.pageLimit, this.currentPage);
+    this.pagedRows = this.pagination ? this.paginate(this.rows, this.pageLimit, this.currentPage) : this.rows;
   }
 
   private paginate(array: TRow[], pageSize: number, currentPage: number) {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-2188

### Change description ###

- it was only showing the first page of rows
- if pagination is set to false then load all rows into the first page

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
