### PR TITLE
DMP-2211 Preventing multiple ID usage on `govuk-textarea` wrapper component

### DIFF
--- a/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.html
+++ b/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.html
@@ -69,10 +69,10 @@
       </div>
       <app-govuk-textarea
         [id]="'change-reason'"
-        name="reason"
-        ariaDescribedBy="change-reason-hint"
+        [name]="'reason'"
+        [ariaDescribedBy]="'change-reason-hint'"
         [control]="retainReasonFormControl"
-        [maxCharacterLimit]="rententionCharacterLimit"
+        [maxCharacterLimit]="retentionCharacterLimit"
         [isInvalid]="isReasonInvalid()"
       ></app-govuk-textarea>
     </div>

--- a/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.spec.ts
+++ b/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.spec.ts
@@ -1,11 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserService } from '@services/user/user.service';
-import { CaseRententionChangeComponent } from './case-retention-change.component';
+import { CaseRetentionChangeComponent } from './case-retention-change.component';
 import { DatePipe } from '@angular/common';
 
 describe('CaseRetentionComponent', () => {
-  let component: CaseRententionChangeComponent;
-  let fixture: ComponentFixture<CaseRententionChangeComponent>;
+  let component: CaseRetentionChangeComponent;
+  let fixture: ComponentFixture<CaseRetentionChangeComponent>;
   let mockUserService: Partial<UserService>;
 
   const currentRetentionDate = '01/01/2024';
@@ -17,10 +17,10 @@ describe('CaseRetentionComponent', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [CaseRententionChangeComponent],
+      imports: [CaseRetentionChangeComponent],
       providers: [{ provide: UserService, useValue: mockUserService }, { provide: DatePipe }],
     });
-    fixture = TestBed.createComponent(CaseRententionChangeComponent);
+    fixture = TestBed.createComponent(CaseRetentionChangeComponent);
     component = fixture.componentInstance;
     component.currentRetentionDate = currentRetentionDate;
     component.originalRetentionDate = originalRetentionDate;

--- a/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.ts
+++ b/src/app/components/case/case-retention-date/case-retention-change/case-retention-change.component.ts
@@ -24,7 +24,7 @@ import { DateTime } from 'luxon';
   templateUrl: './case-retention-change.component.html',
   styleUrls: ['./case-retention-change.component.scss'],
 })
-export class CaseRententionChangeComponent {
+export class CaseRetentionChangeComponent {
   @Input() state!: CaseRetentionPageState;
   @Input() currentRetentionDate!: string | null;
   @Input() originalRetentionDate!: string | null;
@@ -41,7 +41,7 @@ export class CaseRententionChangeComponent {
   datePatternValidator = Validators.pattern(/^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/);
   datePipe = inject(DatePipe);
 
-  rententionCharacterLimit = 200;
+  retentionCharacterLimit = 200;
   errors: { fieldId: string; message: string }[] = [];
 
   errorNoOption = 'Select an option';

--- a/src/app/components/case/case-retention-date/case-retention-date.component.ts
+++ b/src/app/components/case/case-retention-date/case-retention-date.component.ts
@@ -17,7 +17,7 @@ import { DetailsTableComponent } from '../../common/details-table/details-table.
 import { GovukHeadingComponent } from '../../common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '../../common/loading/loading.component';
 import { NotificationBannerComponent } from '../../common/notification-banner/notification-banner.component';
-import { CaseRententionChangeComponent } from './case-retention-change/case-retention-change.component';
+import { CaseRetentionChangeComponent } from './case-retention-change/case-retention-change.component';
 import { CaseRententionConfirmComponent } from './case-retention-confirm/case-retention-confirm.component';
 import { DateTime } from 'luxon';
 
@@ -37,7 +37,7 @@ import { DateTime } from 'luxon';
     RouterLink,
     TableRowTemplateDirective,
     NotificationBannerComponent,
-    CaseRententionChangeComponent,
+    CaseRetentionChangeComponent,
     CaseRententionConfirmComponent,
     SuccessBannerComponent,
   ],

--- a/src/app/components/hearing/request-transcript/request-transcript-confirmation/request-transcript-confirmation.component.html
+++ b/src/app/components/hearing/request-transcript/request-transcript-confirmation/request-transcript-confirmation.component.html
@@ -53,9 +53,9 @@
   </h1>
   <div id="more-detail-hint" class="govuk-hint">Provide any further instructions or comments for the transcriber.</div>
   <app-govuk-textarea
-    id="more-detail"
-    name="moreDetail"
-    ariaDescribedBy="more-detail-hint"
+    [id]="'more-detail'"
+    [name]="'moreDetail'"
+    [ariaDescribedBy]="'more-detail-hint'"
     [control]="moreDetailFormControl"
   ></app-govuk-textarea>
 </div>

--- a/src/app/components/transcriptions/approve-transcript/approve-transcript-buttons/approve-transcript-buttons.component.html
+++ b/src/app/components/transcriptions/approve-transcript/approve-transcript-buttons/approve-transcript-buttons.component.html
@@ -38,9 +38,9 @@
             Why can you not approve this request?
           </label>
           <app-govuk-textarea
-            id="reject-reason"
-            name="reason"
-            ariaDescribedBy="more-detail-hint"
+            [id]="'reject-reason'"
+            [name]="'reason'"
+            [ariaDescribedBy]="'more-detail-hint'"
             [control]="rejectReasonFormControl"
           ></app-govuk-textarea>
         </div>


### PR DESCRIPTION
- also fixing the spelling of "rentention" to "retention"

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-2211

### Change description ###

- fixing multiple ID usage
- fixing spelling issue

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
