### PR TITLE
DMP-2231 Convert retention history date to luxon

### DIFF
--- a/darts-api-stub/retentions/retention.js
+++ b/darts-api-stub/retentions/retention.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const retentionHistory = [
   {
     retention_last_changed_date: '2023-10-11T00:18:00Z',
-    retention_date: '2030-09-15',
+    retention_date: '2025-12-15',
     amended_by: 'Judge Phil',
     retention_policy_applied: 'Permanent',
     comments: 'Permanent policy applied',
@@ -13,7 +13,7 @@ const retentionHistory = [
   },
   {
     retention_last_changed_date: '2023-10-12T00:15:00Z',
-    retention_date: '2030-09-15',
+    retention_date: '2030-07-10',
     amended_by: 'Judge Samuel',
     retention_policy_applied: 'Manual',
     comments: 'Manual policy applied',

--- a/src/app/portal/components/case/case-retention-date/case-retention-date.component.html
+++ b/src/app/portal/components/case/case-retention-date/case-retention-date.component.html
@@ -56,10 +56,12 @@
         [rows]="vm.retentionHistory"
       >
         <ng-template [tableRowTemplate]="vm.retentionHistory" let-row>
-          <td class="govuk-table__cell">{{ row.retention_last_changed_date | date: 'dd MMM yyyy HH:mm:ss' }}</td>
-          <td class="govuk-table__cell">{{ row.retention_date | date: 'dd MMM yyyy' }}</td>
-          <td class="govuk-table__cell">{{ row.amended_by }}</td>
-          <td class="govuk-table__cell">{{ row.retention_policy_applied }}</td>
+          <td class="govuk-table__cell">
+            {{ row.retentionLastChangedDate | luxonDate: 'dd MMM yyyy HH:mm:ss' }}
+          </td>
+          <td class="govuk-table__cell">{{ row.retentionDate | luxonDate: 'dd MMM yyyy' }}</td>
+          <td class="govuk-table__cell">{{ row.amendedBy }}</td>
+          <td class="govuk-table__cell">{{ row.retentionPolicyApplied }}</td>
           <td class="govuk-table__cell">{{ row.comments }}</td>
 
           <td class="govuk-table__cell">

--- a/src/app/portal/components/case/case-retention-date/case-retention-date.component.spec.ts
+++ b/src/app/portal/components/case/case-retention-date/case-retention-date.component.spec.ts
@@ -7,7 +7,8 @@ import { Case } from '@portal-types/case/case.type';
 import { HeaderService } from '@services/header/header.service';
 import { DateTime } from 'luxon';
 import { of } from 'rxjs';
-import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.interface';
+import { CaseRetentionHistoryData } from 'src/app/portal/models/case/case-retention-history.interface';
+import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.type';
 import { CaseService } from 'src/app/portal/services/case/case.service';
 import { CaseRetentionDateComponent } from './case-retention-date.component';
 
@@ -28,7 +29,7 @@ describe('CaseRetentionDateComponent', () => {
     hideNavigation: jest.fn(),
   };
 
-  const mockRetentionHistory: CaseRetentionHistory[] = [
+  const mockRetentionHistory: CaseRetentionHistoryData[] = [
     {
       retention_last_changed_date: '2023-01-01T00:00:00Z',
       retention_date: '2030-09-15',
@@ -50,6 +51,33 @@ describe('CaseRetentionDateComponent', () => {
       retention_date: '2030-09-15',
       amended_by: 'Judge Phil',
       retention_policy_applied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'PENDING',
+    },
+  ];
+
+  const mockRetentionHistoryVm: CaseRetentionHistory[] = [
+    {
+      retentionLastChangedDate: DateTime.fromISO(mockRetentionHistory[0].retention_last_changed_date),
+      retentionDate: DateTime.fromISO(mockRetentionHistory[0].retention_date),
+      amendedBy: 'Judge Phil',
+      retentionPolicyApplied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'COMPLETE',
+    },
+    {
+      retentionLastChangedDate: DateTime.fromISO(mockRetentionHistory[1].retention_last_changed_date),
+      retentionDate: DateTime.fromISO(mockRetentionHistory[1].retention_date),
+      amendedBy: 'Judge Phil',
+      retentionPolicyApplied: 'Permanent',
+      comments: 'Permanent policy applied',
+      status: 'PENDING',
+    },
+    {
+      retentionLastChangedDate: DateTime.fromISO(mockRetentionHistory[2].retention_last_changed_date),
+      retentionDate: DateTime.fromISO(mockRetentionHistory[2].retention_date),
+      amendedBy: 'Judge Phil',
+      retentionPolicyApplied: 'Permanent',
       comments: 'Permanent policy applied',
       status: 'PENDING',
     },
@@ -96,17 +124,17 @@ describe('CaseRetentionDateComponent', () => {
   });
 
   it('#getLatestDate', () => {
-    const result = component.getLatestDate(mockRetentionHistory);
-    expect(result).toEqual(mockRetentionHistory[1]);
+    const result = component.getLatestDate(mockRetentionHistoryVm);
+    expect(result).toEqual(mockRetentionHistoryVm[1]);
   });
 
   it('#getEarliestDate', () => {
-    const result = component.getEarliestDate(mockRetentionHistory);
-    expect(result).toEqual(mockRetentionHistory[0]);
+    const result = component.getEarliestDate(mockRetentionHistoryVm);
+    expect(result).toEqual(mockRetentionHistoryVm[0]);
   });
 
   it('#getOriginalRetentionDateString', () => {
-    const result = component.getOriginalRetentionDateString(mockRetentionHistory);
+    const result = component.getOriginalRetentionDateString(mockRetentionHistoryVm);
     const expectedDateString = mockDatePipe.transform(mockRetentionHistory[0].retention_date, 'dd/MM/yyyy');
     expect(result).toEqual(expectedDateString);
   });
@@ -117,13 +145,13 @@ describe('CaseRetentionDateComponent', () => {
     });
 
     it('should return true if the latest date status is not PENDING', () => {
-      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[0]);
-      expect(component.infoBannerHide(mockRetentionHistory)).toBe(true);
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistoryVm[0]);
+      expect(component.infoBannerHide(mockRetentionHistoryVm)).toBe(true);
     });
 
     it('should return false if the latest date status is PENDING', () => {
-      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[1]);
-      expect(component.infoBannerHide(mockRetentionHistory)).toBe(false);
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistoryVm[1]);
+      expect(component.infoBannerHide(mockRetentionHistoryVm)).toBe(false);
     });
   });
 
@@ -133,18 +161,18 @@ describe('CaseRetentionDateComponent', () => {
     });
 
     it('should return true if the latest date status is not COMPLETE', () => {
-      const mockLatestDate = mockRetentionHistory[2];
+      const mockLatestDate = mockRetentionHistoryVm[2];
       expect(mockLatestDate.status).not.toBe('COMPLETE');
 
       jest.spyOn(component, 'getLatestDate').mockReturnValue(mockLatestDate);
 
-      const result = component.buttonGroupHide(mockRetentionHistory);
+      const result = component.buttonGroupHide(mockRetentionHistoryVm);
       expect(result).toBe(true);
     });
 
     it('should return false if the latest date status is COMPLETE', () => {
-      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistory[0]);
-      expect(component.buttonGroupHide(mockRetentionHistory)).toBe(false);
+      jest.spyOn(component, 'getLatestDate').mockReturnValue(mockRetentionHistoryVm[0]);
+      expect(component.buttonGroupHide(mockRetentionHistoryVm)).toBe(false);
     });
   });
 

--- a/src/app/portal/components/case/case-retention-date/case-retention-date.component.ts
+++ b/src/app/portal/components/case/case-retention-date/case-retention-date.component.ts
@@ -9,7 +9,7 @@ import { Case } from '@portal-types/case/case.type';
 import { HeaderService } from '@services/header/header.service';
 import { DateTime } from 'luxon';
 import { combineLatest, map } from 'rxjs';
-import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.interface';
+import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.type';
 import { CaseRetentionPageState } from 'src/app/portal/models/case/case-retention-page-state.type';
 import { CaseService } from 'src/app/portal/services/case/case.service';
 import { BreadcrumbComponent } from '../../../../components/common/breadcrumb/breadcrumb.component'; //TO DO update as part of core
@@ -18,6 +18,7 @@ import { DetailsTableComponent } from '../../../../components/common/details-tab
 import { GovukHeadingComponent } from '../../../../components/common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '../../../../components/common/loading/loading.component';
 import { NotificationBannerComponent } from '../../../../components/common/notification-banner/notification-banner.component';
+import { LuxonDatePipe } from '../../../../pipes/luxon-date.pipe';
 import { CaseRetentionChangeComponent } from './case-retention-change/case-retention-change.component';
 import { CaseRententionConfirmComponent } from './case-retention-confirm/case-retention-confirm.component';
 
@@ -40,6 +41,7 @@ import { CaseRententionConfirmComponent } from './case-retention-confirm/case-re
     CaseRetentionChangeComponent,
     CaseRententionConfirmComponent,
     SuccessBannerComponent,
+    LuxonDatePipe,
   ],
 })
 export class CaseRetentionDateComponent implements OnInit {
@@ -116,23 +118,21 @@ export class CaseRetentionDateComponent implements OnInit {
 
   getLatestDate(rows: CaseRetentionHistory[]) {
     return rows.reduce(
-      (max, item) =>
-        new Date(item.retention_last_changed_date) > new Date(max.retention_last_changed_date) ? item : max,
+      (max, item) => (item.retentionLastChangedDate > max.retentionLastChangedDate ? item : max),
       rows[0]
     );
   }
 
   getEarliestDate(rows: CaseRetentionHistory[]) {
     return rows.reduce(
-      (max, item) =>
-        new Date(item.retention_last_changed_date) < new Date(max.retention_last_changed_date) ? item : max,
+      (max, item) => (item.retentionLastChangedDate < max.retentionLastChangedDate ? item : max),
       rows[0]
     );
   }
 
   getOriginalRetentionDateString(rows: CaseRetentionHistory[]) {
-    const earliestDate = this.getEarliestDate(rows).retention_date;
-    return DateTime.fromISO(earliestDate, { setZone: true }).toFormat('dd/MM/yyyy');
+    const earliestDate = this.getEarliestDate(rows).retentionDate;
+    return earliestDate.toFormat('dd/MM/yyyy');
   }
 
   changeRetentionDate() {

--- a/src/app/portal/models/case/case-retention-history.interface.ts
+++ b/src/app/portal/models/case/case-retention-history.interface.ts
@@ -1,4 +1,4 @@
-export interface CaseRetentionHistory {
+export interface CaseRetentionHistoryData {
   retention_last_changed_date: string;
   retention_date: string;
   amended_by: string;

--- a/src/app/portal/models/case/case-retention-history.type.ts
+++ b/src/app/portal/models/case/case-retention-history.type.ts
@@ -1,0 +1,10 @@
+import { DateTime } from 'luxon';
+
+export type CaseRetentionHistory = {
+  retentionLastChangedDate: DateTime;
+  retentionDate: DateTime;
+  amendedBy: string;
+  retentionPolicyApplied: string;
+  comments: string;
+  status: string;
+};

--- a/src/app/portal/services/case/case.service.spec.ts
+++ b/src/app/portal/services/case/case.service.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@portal-types/index';
 import { DateTime, Settings } from 'luxon';
 import { CaseRetentionChange } from 'src/app/portal/models/case/case-retention-change.interface';
-import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.interface';
+import { CaseRetentionHistoryData } from 'src/app/portal/models/case/case-retention-history.interface';
 import {
   ADVANCED_SEARCH_CASE_PATH,
   CaseService,
@@ -85,7 +85,7 @@ describe('CaseService', () => {
     transcript_count: 300,
   };
 
-  const mockHistory: CaseRetentionHistory = {
+  const mockHistory: CaseRetentionHistoryData = {
     retention_last_changed_date: '2023-10-11T00:18:00Z',
     retention_date: '2030-09-15',
     amended_by: 'Judge Phil',
@@ -345,7 +345,7 @@ describe('CaseService', () => {
 
   it('#getCaseRetentionHistory', () => {
     const mockCaseId = 123;
-    const mock: CaseRetentionHistory[] = [mockHistory];
+    const mock: CaseRetentionHistoryData[] = [mockHistory];
 
     service.getCaseRetentionHistory(mockCaseId).subscribe((history) => {
       expect(history).toBeDefined();

--- a/src/app/portal/services/case/case.service.ts
+++ b/src/app/portal/services/case/case.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Courthouse, SearchFormValues } from '@darts-types/index';
+import { CaseRetentionHistory } from '@portal-types/case/case-retention-history.type';
 import { Case, CaseData, Hearing, HearingData, Transcript, TranscriptData } from '@portal-types/index';
 import { DateTime } from 'luxon';
 import { Observable } from 'rxjs/internal/Observable';
@@ -9,7 +10,7 @@ import { catchError } from 'rxjs/internal/operators/catchError';
 import { map } from 'rxjs/internal/operators/map';
 import { shareReplay } from 'rxjs/internal/operators/shareReplay';
 import { CaseRetentionChange } from 'src/app/portal/models/case/case-retention-change.interface';
-import { CaseRetentionHistory } from 'src/app/portal/models/case/case-retention-history.interface';
+import { CaseRetentionHistoryData } from 'src/app/portal/models/case/case-retention-history.interface';
 
 export const GET_COURTHOUSES_PATH = '/api/courthouses';
 export const GET_CASE_PATH = '/api/cases';
@@ -99,11 +100,24 @@ export class CaseService {
   getCaseRetentionHistory(caseId: number): Observable<CaseRetentionHistory[]> {
     let params = new HttpParams();
     params = params.set('case_id', caseId);
-    return this.http.get<CaseRetentionHistory[]>(GET_CASE_RETENTION_HISTORY, { params });
+    return this.http
+      .get<CaseRetentionHistoryData[]>(GET_CASE_RETENTION_HISTORY, { params })
+      .pipe(map(this.mapCaseRetentionHistory));
   }
 
   postCaseRetentionChange(retentionChange: CaseRetentionChange): Observable<CaseRetentionChange> {
     return this.http.post<CaseRetentionChange>(GET_CASE_RETENTION_HISTORY, retentionChange);
+  }
+
+  private mapCaseRetentionHistory(retentionHistory: CaseRetentionHistoryData[]): CaseRetentionHistory[] {
+    return retentionHistory.map((r) => ({
+      retentionLastChangedDate: DateTime.fromISO(r.retention_last_changed_date),
+      retentionDate: DateTime.fromISO(r.retention_date),
+      amendedBy: r.amended_by,
+      retentionPolicyApplied: r.retention_policy_applied,
+      comments: r.comments,
+      status: r.status,
+    }));
   }
 
   private mapHearingDataToHearing(hearingData: HearingData[]): Hearing[] {


### PR DESCRIPTION
[### Jira link (if applicable)
](https://tools.hmcts.net/jira/browse/DMP-2231)

Bug fix for retention date history BST dates showing a day behind.

Converted retention history dates to use luxon DateTime.

### Checklist
- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
