### PR TITLE
DMP 1756 - Dupe transcript page updates

### DIFF
--- a/cypress/e2e/functional/request-transcript-spec.cy.js
+++ b/cypress/e2e/functional/request-transcript-spec.cy.js
@@ -217,7 +217,8 @@ describe('Request Transcript', () => {
       // Submit the form
       cy.get('.govuk-button').contains('Submit request').click();
 
-      cy.get('.govuk-heading-l').should('contain', 'This transcript already exists');
+      cy.get('.govuk-heading-l').should('contain', 'This transcript was requested already');
+      cy.get('.govuk-body').should('contain', 'If the request is complete, a transcript will be available below.');
     });
 
     it('should show duplicate error message during court log transcript request', () => {
@@ -251,7 +252,8 @@ describe('Request Transcript', () => {
       cy.get('#authorisation').check({ force: true });
       cy.get('.govuk-button').contains('Submit request').click();
 
-      cy.get('.govuk-heading-l').should('contain', 'This transcript already exists');
+      cy.get('.govuk-heading-l').should('contain', 'This transcript was requested already');
+      cy.get('.govuk-body').should('contain', 'If the request is complete, a transcript will be available below.');
       cy.a11y();
     });
 
@@ -272,7 +274,8 @@ describe('Request Transcript', () => {
       cy.get('#authorisation').check({ force: true });
       cy.get('.govuk-button').contains('Submit request').click();
 
-      cy.get('.govuk-heading-l').should('contain', 'This transcript already exists');
+      cy.get('.govuk-heading-l').should('contain', 'This transcript was requested already');
+      cy.get('.govuk-body').should('contain', 'If the request is complete, a transcript will be available below.');
       cy.get('#exists-hearing-route').contains('Return to hearing').click();
 
       cy.get('.govuk-heading-m').should('contain', 'Transcripts for this hearing');
@@ -295,10 +298,11 @@ describe('Request Transcript', () => {
       cy.get('#authorisation').check({ force: true });
       cy.get('.govuk-button').contains('Submit request').click();
 
-      cy.get('.govuk-heading-l').should('contain', 'This transcript already exists');
-      cy.get('.govuk-link').should('contain', 'Go to this transcript');
+      cy.get('.govuk-heading-l').should('contain', 'This transcript was requested already');
+      cy.get('.govuk-body').should('contain', 'If the request is complete, a transcript will be available below.');
+      cy.get('.govuk-link').should('contain', 'Go to transcript');
 
-      cy.get('#exists-duplicate-route').contains('Go to this transcript').click();
+      cy.get('#exists-duplicate-route').contains('Go to transcript').click();
 
       cy.get('.govuk-caption-l').should('contain', 'Transcript file');
       cy.get('.govuk-heading-l').should('contain', 'C20220620001_0.docx');

--- a/darts-api-stub/transcriptions/transcriptions.js
+++ b/darts-api-stub/transcriptions/transcriptions.js
@@ -493,7 +493,7 @@ router.post('/', (req, res) => {
   const dupe = req.body.transcription_type_id == 0 && true;
 
   if (exists || dupe) {
-    res.status(409).send({ duplicate_transcription_id: 1 });
+    res.status(409).send({ duplicate_transcription_id: 1, detail: 'Duplicated' });
   } else {
     res.send({ transcription_id: 123 });
   }

--- a/src/app/portal/components/hearing/request-transcript/request-transcript-exists/request-transcript-exists.component.html
+++ b/src/app/portal/components/hearing/request-transcript/request-transcript-exists/request-transcript-exists.component.html
@@ -1,13 +1,7 @@
-<h1 class="govuk-heading-l">This transcript already exists</h1>
+<h1 class="govuk-heading-l">This transcript was requested already</h1>
 
+<p class="govuk-body">If the request is complete, a transcript will be available below.</p>
 <div class="govuk-button-group">
-  <a
-    id="exists-duplicate-route"
-    class="govuk-link"
-    [routerLink]="['../', 'transcripts', transcriptionId]"
-    routerLinkActive="router-link-active"
-    >Go to this transcript</a
-  >
   <a
     id="exists-hearing-route"
     class="govuk-link"
@@ -16,4 +10,14 @@
     routerLinkActive="router-link-active"
     >Return to hearing</a
   >
+
+  @if (transcriptionId) {
+    <a
+      id="exists-duplicate-route"
+      class="govuk-link"
+      [routerLink]="['../', 'transcripts', transcriptionId]"
+      routerLinkActive="router-link-active"
+      >Go to transcript</a
+    >
+  }
 </div>


### PR DESCRIPTION
[DMP-1756](https://tools.hmcts.net/jira/browse/DMP-1756)

Minor screen updates

When a transcript request is still in progress, the "Go to transcript" link will not be visible. To test this, remove duplicate_transcription_id from body in stub. Body should not be completely empty.

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
