### PR TITLE
DMP-2161 [UPDATE] - Render new line characters in error messages

### DIFF
--- a/cypress/e2e/functional/case-retention-spec.cy.js
+++ b/cypress/e2e/functional/case-retention-spec.cy.js
@@ -130,11 +130,11 @@ describe('Case retention screen as standard user', () => {
       cy.get('.govuk-error-message').should('exist');
       cy.get('.govuk-error-summary').should(
         'contain',
-        'You do not have permission to reduce the current retention date. Please refer to the DARTS retention policy guidance'
+        'You do not have permission to reduce the current retention date.\r\nPlease refer to the DARTS retention policy guidance'
       );
       cy.get('.govuk-error-message').should(
         'contain',
-        'You do not have permission to reduce the current retention date. Please refer to the DARTS retention policy guidance'
+        'You do not have permission to reduce the current retention date.\r\nPlease refer to the DARTS retention policy guidance'
       );
 
       // Fill it in properly this time, error message should not appear

--- a/src/app/core/components/common/datepicker/datepicker.component.scss
+++ b/src/app/core/components/common/datepicker/datepicker.component.scss
@@ -1,0 +1,3 @@
+p {
+  white-space: pre-line;
+}

--- a/src/app/core/components/common/validation-error-summary/validation-error-summary.component.scss
+++ b/src/app/core/components/common/validation-error-summary/validation-error-summary.component.scss
@@ -1,0 +1,3 @@
+a {
+  white-space: pre-line;
+}

--- a/src/app/portal/components/case/case-retention-date/case-retention-change/case-retention-change.component.spec.ts
+++ b/src/app/portal/components/case/case-retention-date/case-retention-change/case-retention-change.component.spec.ts
@@ -119,7 +119,7 @@ describe('CaseRetentionComponent', () => {
       component.onConfirm();
 
       expect(component.errorDate).toEqual(
-        'You do not have permission to reduce the current retention date. Please refer to the DARTS retention policy guidance'
+        'You do not have permission to reduce the current retention date.\r\nPlease refer to the DARTS retention policy guidance'
       );
     });
 

--- a/src/app/portal/components/case/case-retention-date/case-retention-change/case-retention-change.component.ts
+++ b/src/app/portal/components/case/case-retention-date/case-retention-change/case-retention-change.component.ts
@@ -157,7 +157,7 @@ export class CaseRetentionChangeComponent {
               this.errorDate = `You cannot set retention date earlier than ${earliestDate.toFormat(this.datePageFormat)}`;
             } else {
               // Otherwise, the only other error can be a permissions issue
-              this.errorDate = `You do not have permission to reduce the current retention date. Please refer to the DARTS retention policy guidance`;
+              this.errorDate = `You do not have permission to reduce the current retention date.\r\nPlease refer to the DARTS retention policy guidance`;
             }
             this.errors.push({
               fieldId: 'retention-date',


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2161](https://tools.hmcts.net/jira/browse/DMP-2161)

### Change description ###
Adds `white-space: pre-line;` to datepicker and validation-error components so that error messages can span across multiple lines:
![image](https://github.com/hmcts/darts-portal/assets/149702321/a203c2fb-4a2e-4e16-941b-c0400e5ec95c)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
