### PR TITLE
DMP-1614 Fixing annotation document download for production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:darts-api-stg": "DARTS_API_URL=https://darts-api.staging.platform.hmcts.net concurrently --names \"VERIFY-STG-ACCESS,NODE,ANGULAR\" -c \"bgRed.bold,bgBlue.bold,bgGreen.bold\" \"yarn verify-stg-access\" \"yarn dev:node\" \"yarn watch\"",
     "dev:darts-api-stub": "DARTS_API_URL=http://localhost:4551 concurrently --names \"DARTS-API-STUB,NODE,ANGULAR\" -c \"bgRed.bold,bgBlue.bold,bgGreen.bold\" \"yarn darts-api-stub\" \"yarn dev:node\" \"yarn watch\"",
     "darts-api-stub": "node darts-api-stub",
-    "build:node": "yarn tsc -p ./server/tsconfig.json && cp -R ./server/assets ./dist/server",
+    "build:node": "yarn tsc -p ./server/tsconfig.json && cp -R ./server/assets ./dist/server && cp -R ./server/downloads ./dist/server",
     "build:ng": "ng build --configuration production",
     "build": "yarn build:node && yarn build:ng",
     "build:ssr": "yarn build",


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-1614

### Change description ###

- the downloads directory must be copied into dist during the build

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
