### PR TITLE
DMP-2455: Add label for annotation comments

### DIFF
--- a/src/app/portal/components/hearing/add-annotation/add-annotation.component.html
+++ b/src/app/portal/components/hearing/add-annotation/add-annotation.component.html
@@ -11,7 +11,9 @@
     label="Upload annotation file"
     hint="This must be in a doc or docx format. Maximum file size 20MB."
   ></app-file-upload>
-  <app-govuk-heading tag="h2" size="m">Comments</app-govuk-heading>
+  <label for="annotation-comments">
+    <app-govuk-heading tag="h2" size="m">Comments</app-govuk-heading>
+  </label>
   <app-govuk-textarea
     [id]="'annotation-comments'"
     [name]="'comments'"


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2455](https://tools.hmcts.net/jira/browse/DMP-2455)

### Change description ###

- Add label for annotation comments on _Add annotation_ screen
- Stub link: http://localhost:3000/case/1/hearing/1/add-annotation
