### PR TITLE
DMP-2257: Remove tabIndex from headings and use aria role alert instead

### DIFF
--- a/src/app/core/components/common/govuk-heading/govuk-heading.component.html
+++ b/src/app/core/components/common/govuk-heading/govuk-heading.component.html
@@ -1,21 +1,21 @@
 @switch (tag) {
   @case ('h1') {
-    <h1 [class]="headingClass" tabindex="0">
+    <h1 [class]="headingClass" [attr.role]="ariaRole">
       <ng-container *ngTemplateOutlet="text"></ng-container>
     </h1>
   }
   @case ('h2') {
-    <h2 [class]="headingClass" tabindex="0">
+    <h2 [class]="headingClass" [attr.role]="ariaRole">
       <ng-container *ngTemplateOutlet="text"></ng-container>
     </h2>
   }
   @case ('h3') {
-    <h3 [class]="headingClass" tabindex="0">
+    <h3 [class]="headingClass" [attr.role]="ariaRole">
       <ng-container *ngTemplateOutlet="text"></ng-container>
     </h3>
   }
   @case ('h4') {
-    <h4 [class]="headingClass" tabindex="0">
+    <h4 [class]="headingClass" [attr.role]="ariaRole">
       <ng-container *ngTemplateOutlet="text"></ng-container>
     </h4>
   }

--- a/src/app/core/components/common/govuk-heading/govuk-heading.component.ts
+++ b/src/app/core/components/common/govuk-heading/govuk-heading.component.ts
@@ -14,6 +14,7 @@ export class GovukHeadingComponent implements OnInit {
   @Input() tag: 'h1' | 'h2' | 'h3' | 'h4' = 'h1';
   @Input() headingClass = '';
   @Input() captionClass = '';
+  @Input() ariaRole = '';
 
   ngOnInit(): void {
     this.headingClass = `govuk-heading-${this.size}`;

--- a/src/app/core/components/error/conflict/conflict.component.html
+++ b/src/app/core/components/error/conflict/conflict.component.html
@@ -1,5 +1,5 @@
-<app-govuk-heading> {{ header || 'This request is no longer available' }}</app-govuk-heading>
-<p id="conflict-body" class="govuk-body" tabindex="0">
+<app-govuk-heading ariaRole="alert"> {{ header || 'This request is no longer available' }}</app-govuk-heading>
+<p id="conflict-body" class="govuk-body" role="alert">
   {{ body || 'Another user may have already actioned this request.' }}
 </p>
 <a [routerLink]="[link?.href || '/transcriptions']" id="return-link" class="govuk-link">{{

--- a/src/app/core/components/error/forbidden/forbidden.component.html
+++ b/src/app/core/components/error/forbidden/forbidden.component.html
@@ -1,4 +1,4 @@
-<h1 id="forbidden-heading" class="govuk-heading-xl govuk-!-margin-bottom-8">
+<h1 id="forbidden-heading" role="alert" class="govuk-heading-xl govuk-!-margin-bottom-8">
   {{ header || 'You do not have permission to access this page' }}
 </h1>
 <p id="forbidden-body" class="govuk-body">

--- a/src/app/core/components/error/internal-server/internal-error.component.html
+++ b/src/app/core/components/error/internal-server/internal-error.component.html
@@ -3,10 +3,10 @@
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 *ngIf="!error.display || error.display === 'PAGE'" class="govuk-heading-l">
+          <h1 *ngIf="!error.display || error.display === 'PAGE'" class="govuk-heading-l" role="alert">
             There is a problem with the service
           </h1>
-          <h2 *ngIf="error.display === 'COMPONENT'" class="govuk-heading-l">An error has occurred.</h2>
+          <h2 *ngIf="error.display === 'COMPONENT'" class="govuk-heading-l" role="alert">An error has occurred.</h2>
           <!-- We should add unique identification for support requests later on -->
           <p class="govuk-body">
             Try again or
@@ -23,7 +23,7 @@
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">There is a problem with the service</h1>
+          <h1 class="govuk-heading-l" role="alert">There is a problem with the service</h1>
           <p class="govuk-body">
             Try again or
             <a href="mailto:{{ support?.emailAddress }}" class="govuk-link">contact {{ support?.name }}</a> if the

--- a/src/app/core/components/error/not-found/not-found.component.html
+++ b/src/app/core/components/error/not-found/not-found.component.html
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-8">Page not found</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-8" role="alert">Page not found</h1>
 <p class="govuk-body">
   <a routerLink="/search" class="govuk-link">Go to search</a>
 </p>


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2257](https://tools.hmcts.net/jira/browse/DMP-2257)

### Change description ###

- Remove tabIndex from headings and use aria role alert instead for error pages

Ignore branch name, incorrect ticket number
