### PR TITLE
DMP-2278: Groups admin screen

### DIFF
--- a/cypress/e2e/functional/admin-portal/groups-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/groups-spec.cy.js
@@ -1,0 +1,42 @@
+import 'cypress-axe';
+import '../commands';
+describe('Admin - Groups screen', () => {
+  beforeEach(() => {
+    cy.login('admin');
+    cy.visit('/admin/groups');
+    cy.injectAxe();
+  });
+
+  it('load page', () => {
+    cy.get('h1').should('contain', 'Groups');
+    cy.a11y();
+  });
+
+  it('render groups table', () => {
+    cy.get('#groups-table').should('contain', 'Judiciary');
+    cy.get('#groups-table').should('contain', 'Approver');
+
+    cy.get('#groups-table').should('contain', 'Opus Transcribers');
+    cy.get('#groups-table').should('contain', 'Requestor');
+
+    cy.get('#groups-table').should('contain', 'Super user (DARTS portal)');
+    cy.get('#groups-table').should('contain', 'Judge');
+
+    cy.get('#groups-table').should('contain', 'Admin (Admin portal)');
+    cy.get('#groups-table').should('contain', 'Transcriber');
+
+    cy.get('#groups-table').should('contain', 'Super admin (Admin portal)');
+    cy.get('#groups-table').should('contain', 'Translation QA');
+  });
+
+  it('filter groups', () => {
+    cy.get('#search').type('Judiciary');
+    cy.get('#roles-filter').select('Approver');
+
+    cy.get('#groups-table').should('contain', 'Judiciary');
+    cy.get('#groups-table').should('contain', 'Approver');
+
+    cy.get('#groups-table').should('not.contain', 'Opus Transcribers');
+    cy.get('#groups-table').should('not.contain', 'Requestor');
+  });
+});

--- a/src/app/admin/admin.routes.ts
+++ b/src/app/admin/admin.routes.ts
@@ -42,6 +42,10 @@ export const ADMIN_ROUTES: Routes = [
       import('./components/users/user-record/user-record.component').then((c) => c.UserRecordComponent),
   },
   {
+    path: 'admin/groups',
+    loadComponent: () => import('./components/groups/groups.component').then((c) => c.GroupsComponent),
+  },
+  {
     path: 'admin/courthouses',
     loadComponent: () => import('./components/courthouses/courthouses.component').then((c) => c.CourthousesComponent),
   },

--- a/src/app/admin/components/courthouses/courthouse-record/courthouse-record.component.spec.ts
+++ b/src/app/admin/components/courthouses/courthouse-record/courthouse-record.component.spec.ts
@@ -1,4 +1,5 @@
 import { Courthouse } from '@admin-types/courthouses/courthouse.type';
+import { SecurityGroup } from '@admin-types/users/security-group.type';
 import { DatePipe } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -7,7 +8,6 @@ import { CourthouseService } from '@services/courthouses/courthouses.service';
 import { DateTime } from 'luxon';
 import { of } from 'rxjs';
 import { CourthouseRecordComponent } from './courthouse-record.component';
-import { SecurityGroup } from '@admin-types/users/security-group.type';
 
 describe('CourthouseRecordComponent', () => {
   let component: CourthouseRecordComponent;
@@ -65,7 +65,7 @@ describe('CourthouseRecordComponent', () => {
     const groups: SecurityGroup[] = [
       { id: 1, securityRoleId: 1, name: 'Group 1' },
       { id: 2, securityRoleId: 2, name: 'Group 2' },
-    ];
+    ] as SecurityGroup[];
     expect(component.formatSecurityGroupLinks(groups)).toStrictEqual([
       { value: 'Group 1', href: '/admin/groups/1' },
       { value: 'Group 2', href: '/admin/groups/2' },

--- a/src/app/admin/components/courthouses/create-courthouse/create-update-courthouse-confirmation/create-update-courthouse-confirmation.component.spec.ts
+++ b/src/app/admin/components/courthouses/create-courthouse/create-update-courthouse-confirmation/create-update-courthouse-confirmation.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { CreateUpdateCourthouseFormValues, SecurityGroup } from '@admin-types/index';
 import { CreateUpdateCourthouseConfirmationComponent } from './create-update-courthouse-confirmation.component';
-import { CreateUpdateCourthouseFormValues } from '@admin-types/index';
 
 describe('CreateUpdateCourthouseConfirmationComponent', () => {
   let component: CreateUpdateCourthouseConfirmationComponent;
@@ -27,7 +27,7 @@ describe('CreateUpdateCourthouseConfirmationComponent', () => {
         component.companies = [
           { id: 0, name: 'Company 1' },
           { id: 1, name: 'Company 2' },
-        ];
+        ] as SecurityGroup[];
         component.regions = [
           { id: 0, name: 'Region 1' },
           { id: 1, name: 'Region 2' },
@@ -55,7 +55,7 @@ describe('CreateUpdateCourthouseConfirmationComponent', () => {
         component.companies = [
           { id: 0, name: 'Company 1' },
           { id: 1, name: 'Company 2' },
-        ];
+        ] as SecurityGroup[];
         component.regions = [
           { id: 0, name: 'Region 1' },
           { id: 1, name: 'Region 2' },

--- a/src/app/admin/components/courthouses/create-courthouse/create-update-courthouse-form/create-update-courthouse-form.component.spec.ts
+++ b/src/app/admin/components/courthouses/create-courthouse/create-update-courthouse-form/create-update-courthouse-form.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 
-import { CreateUpdateCourthouseFormValues } from '@admin-types/index';
+import { CreateUpdateCourthouseFormValues, SecurityGroup } from '@admin-types/index';
+import { CourthouseService } from '@services/courthouses/courthouses.service';
 import { of } from 'rxjs';
 import { CreateUpdateCourthouseFormComponent } from './create-update-courthouse-form.component';
-import { CourthouseService } from '@services/courthouses/courthouses.service';
 
 type formValidationTestCase = {
   name: string;
@@ -140,7 +140,7 @@ describe('CreateUpdateCourthouseFormComponent', () => {
       const companies = [
         { id: 0, name: 'Company 1' },
         { id: 1, name: 'Company 2' },
-      ];
+      ] as SecurityGroup[];
       component.companies = companies;
       component.selectCompany('1');
       expect(component.selectedCompany).toEqual(companies[1]);
@@ -153,7 +153,7 @@ describe('CreateUpdateCourthouseFormComponent', () => {
         { id: 0, name: 'Company 1' },
         { id: 1, name: 'Company 2' },
         { id: 2, name: 'Company 3' },
-      ];
+      ] as SecurityGroup[];
       component.companies = companies;
       component.selectCompany('1');
       component.addCompany();
@@ -169,7 +169,7 @@ describe('CreateUpdateCourthouseFormComponent', () => {
         { id: 0, name: 'Company 1' },
         { id: 1, name: 'Company 2' },
         { id: 2, name: 'Company 3' },
-      ];
+      ] as SecurityGroup[];
       component.selectedCompanies = [...companies];
       component.removeCompany(1);
       expect(component.selectedCompanies).toEqual([companies[0], companies[2]]);

--- a/src/app/admin/components/groups/groups.component.html
+++ b/src/app/admin/components/groups/groups.component.html
@@ -1,0 +1,41 @@
+<div class="heading-button-container">
+  <app-govuk-heading>Groups</app-govuk-heading>
+  <button class="govuk-button govuk-button--secondary">Create group</button>
+</div>
+
+@if (data$ | async; as data) {
+  <div class="content-container">
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="search">Filter by name</label>
+      <input
+        class="govuk-input"
+        type="text"
+        id="search"
+        [formControl]="searchFormControl"
+        [class.govuk-input--error]="searchFormControl.errors"
+      />
+    </div>
+
+    <label class="govuk-label" for="roles-filter">Role</label>
+    <select class="govuk-select" id="roles-filter" name="transcription-type" [formControl]="rolesFormControl">
+      <option value="" selected></option>
+      @for (role of data.roles; track role.name) {
+        <option [value]="role.name">{{ role.name }}</option>
+      }
+    </select>
+
+    <app-data-table id="groups-table" [columns]="columns" [rows]="data.groups">
+      <ng-template [tableRowTemplate]="data.groups" let-row>
+        <td class="govuk-table__cell">
+          <a class="govuk-link" href="javascript:void(0)">{{ row.name }}</a>
+        </td>
+        <td class="govuk-table__cell">{{ row.description }}</td>
+        <td class="govuk-table__cell">{{ row.role?.name }}</td>
+      </ng-template>
+    </app-data-table>
+  </div>
+}
+
+@if (loading$ | async) {
+  <app-loading />
+}

--- a/src/app/admin/components/groups/groups.component.scss
+++ b/src/app/admin/components/groups/groups.component.scss
@@ -1,0 +1,18 @@
+input,
+select {
+  width: 50%;
+}
+
+app-data-table {
+  display: block;
+  margin-top: 2rem;
+}
+
+.content-container {
+  width: 66%;
+}
+
+.heading-button-container {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/admin/components/groups/groups.component.spec.ts
+++ b/src/app/admin/components/groups/groups.component.spec.ts
@@ -1,0 +1,81 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SecurityGroup } from '@admin-types/index';
+import { GroupsService } from '@services/groups/groups.service';
+import { of } from 'rxjs';
+import { GroupsComponent } from './groups.component';
+
+describe('GroupsComponent', () => {
+  let component: GroupsComponent;
+  let fixture: ComponentFixture<GroupsComponent>;
+  const mockGroupsAndRoles = {
+    groups: [
+      {
+        id: 1,
+        name: 'Group 1',
+        securityRoleId: 1,
+        role: { id: 1, name: 'Role 1', displayState: true },
+      },
+      {
+        id: 2,
+        name: 'Group 2',
+        securityRoleId: 2,
+        role: { id: 2, name: 'Role 2', displayState: false },
+      },
+    ],
+    roles: [
+      { id: 1, name: 'Role 1', displayState: true },
+      { id: 2, name: 'Role 2', displayState: false },
+    ],
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GroupsComponent],
+      providers: [
+        { provide: GroupsService, useValue: { getGroupsAndRoles: jest.fn().mockReturnValue(of(mockGroupsAndRoles)) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GroupsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should display only visible groups and roles', () => {
+    fixture.detectChanges();
+    const groupsTable = fixture.nativeElement.querySelector('#groups-table');
+
+    expect(groupsTable.textContent).toContain('Group 1');
+    expect(groupsTable.textContent).not.toContain('Group 2');
+
+    expect(groupsTable.textContent).toContain('Role 1');
+    expect(groupsTable.textContent).not.toContain('Role 2');
+  });
+
+  it('should filter groups based on search and role', () => {
+    component.searchFormControl.setValue('Group 1');
+    component.rolesFormControl.setValue('Role 1');
+
+    fixture.detectChanges();
+
+    let filterResults: SecurityGroup[] = [];
+
+    component.filteredGroups$.subscribe((filteredGroups) => {
+      filterResults = filteredGroups;
+    });
+
+    expect(filterResults.length).toEqual(1);
+    expect(filterResults[0].name).toEqual('Group 1');
+  });
+
+  it('should update loading state when data is fetched', () => {
+    expect(component.loading$.value).toEqual(true);
+    fixture.detectChanges();
+    expect(component.loading$.value).toEqual(false);
+  });
+});

--- a/src/app/admin/components/groups/groups.component.ts
+++ b/src/app/admin/components/groups/groups.component.ts
@@ -1,0 +1,81 @@
+import { SecurityGroup } from '@admin-types/index';
+import { AsyncPipe, JsonPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { DataTableComponent } from '@common/data-table/data-table.component';
+import { CheckboxListComponent } from '@common/filters/checkbox-list/checkbox-list.component';
+import { GovukDetailsComponent } from '@common/govuk-details/govuk-details.component';
+import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
+import { LoadingComponent } from '@common/loading/loading.component';
+import { DatatableColumn } from '@core-types/index';
+import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { GroupsService } from '@services/groups/groups.service';
+import { BehaviorSubject, combineLatest, map, shareReplay, startWith, tap } from 'rxjs';
+
+@Component({
+  selector: 'app-groups',
+  standalone: true,
+  imports: [
+    GovukHeadingComponent,
+    DataTableComponent,
+    TableRowTemplateDirective,
+    ReactiveFormsModule,
+    AsyncPipe,
+    JsonPipe,
+    CheckboxListComponent,
+    GovukDetailsComponent,
+    LoadingComponent,
+  ],
+  templateUrl: './groups.component.html',
+  styleUrl: './groups.component.scss',
+})
+export class GroupsComponent {
+  groupsService = inject(GroupsService);
+  fb = inject(FormBuilder);
+
+  form = this.fb.group({
+    search: '',
+    roles: [],
+  });
+
+  columns: DatatableColumn[] = [
+    { name: 'Name', prop: 'name', sortable: false },
+    { name: 'Description', prop: 'description', sortable: false },
+    { name: 'Role', prop: 'role', sortable: false },
+  ];
+
+  loading$ = new BehaviorSubject<boolean>(true);
+  groupsAndRoles$ = this.groupsService.getGroupsAndRoles().pipe(shareReplay(1));
+  groups$ = this.groupsAndRoles$.pipe(map((security) => security.groups.filter((group) => group.role?.displayState)));
+  roles$ = this.groupsAndRoles$.pipe(map((security) => security.roles.filter((role) => role.displayState)));
+
+  filteredGroups$ = combineLatest([
+    this.groups$,
+    this.searchFormControl.valueChanges.pipe(startWith('')),
+    this.rolesFormControl.valueChanges.pipe(startWith('')),
+  ]).pipe(
+    map(([groups, search, role]) => {
+      return groups.filter((group) => this.searchFilter(search, group)).filter((group) => this.roleFilter(role, group));
+    })
+  );
+
+  data$ = combineLatest({ groups: this.filteredGroups$, roles: this.roles$ }).pipe(
+    tap(() => this.loading$.next(false))
+  );
+
+  get searchFormControl() {
+    return this.form.get('search') as FormControl;
+  }
+
+  get rolesFormControl() {
+    return this.form.get('roles') as FormControl;
+  }
+
+  private roleFilter(role: string, group: SecurityGroup): boolean {
+    return role.length ? role === group.role?.name : true;
+  }
+
+  private searchFilter(search: string, group: SecurityGroup): boolean {
+    return search ? group.name.toLowerCase().includes(search?.toLowerCase()) : true;
+  }
+}

--- a/src/app/admin/components/users/user-groups/assign-groups/assign-groups.component.ts
+++ b/src/app/admin/components/users/user-groups/assign-groups/assign-groups.component.ts
@@ -4,6 +4,7 @@ import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '@common/loading/loading.component';
+import { GroupsService } from '@services/groups/groups.service';
 import { HeaderService } from '@services/header/header.service';
 import { UserAdminService } from '@services/user-admin/user-admin.service';
 import { Observable, map } from 'rxjs';
@@ -20,15 +21,16 @@ export class AssignGroupsComponent implements OnInit, OnDestroy {
   router = inject(Router);
   userAdminService = inject(UserAdminService);
   headerService = inject(HeaderService);
+  groupsService = inject(GroupsService);
 
   user = this.router.getCurrentNavigation()?.extras.state?.user as User;
 
   // store the hidden groups so we can put them back in when assigning
   usersHiddenGroups = this.user?.securityGroups?.filter((group) => !group.role?.displayState) ?? [];
 
-  groups$: Observable<UserGroup[]> = this.userAdminService
-    .getSecurityGroupsWithRoles()
-    .pipe(map(this.mapSecurityGroupsToUserGroups)) // map to view model
+  groups$: Observable<UserGroup[]> = this.groupsService
+    .getGroupsAndRoles()
+    .pipe(map((data) => this.mapSecurityGroupsToUserGroups(data.groups))) //flatten view model
     .pipe(map((groups) => groups.filter((group) => group.displayState))); // filter out hidden groups for the UI
 
   ngOnInit() {

--- a/src/app/admin/components/users/user-groups/remove-groups/remove-groups.component.spec.ts
+++ b/src/app/admin/components/users/user-groups/remove-groups/remove-groups.component.spec.ts
@@ -19,7 +19,7 @@ const mockGroupsWithRoles: SecurityGroup[] = [
     securityRoleId: 2,
     role: { id: 2, name: 'Role 2', displayState: false },
   },
-];
+] as SecurityGroup[];
 
 const mockUser: User = {
   id: 1,

--- a/src/app/admin/components/users/user-groups/user-groups/user-groups.component.spec.ts
+++ b/src/app/admin/components/users/user-groups/user-groups/user-groups.component.spec.ts
@@ -16,7 +16,7 @@ const mockGroupsWithRoles: SecurityGroup[] = [
     securityRoleId: 2,
     role: { id: 2, name: 'Role 2', displayState: false },
   },
-];
+] as SecurityGroup[];
 
 const mockUser: User = {
   id: 1,

--- a/src/app/admin/models/users/security-group.interface.ts
+++ b/src/app/admin/models/users/security-group.interface.ts
@@ -1,6 +1,7 @@
 export interface SecurityGroupData {
   id: number;
   name: string;
-  display_name?: string;
+  display_name: string;
   security_role_id: number;
+  description: string;
 }

--- a/src/app/admin/models/users/security-group.type.ts
+++ b/src/app/admin/models/users/security-group.type.ts
@@ -5,4 +5,5 @@ export type SecurityGroup = {
   name: string;
   securityRoleId?: number;
   role?: SecurityRole;
+  description: string;
 };

--- a/src/app/admin/services/courthouses/courthouses.service.ts
+++ b/src/app/admin/services/courthouses/courthouses.service.ts
@@ -129,6 +129,7 @@ export class CourthouseService {
         id: group.id!,
         name: group.name!,
         displayName: group.display_name,
+        description: group.description,
       };
     });
   }

--- a/src/app/admin/services/groups/groups.service.spec.ts
+++ b/src/app/admin/services/groups/groups.service.spec.ts
@@ -1,0 +1,200 @@
+import { SecurityGroup, SecurityRole } from '@admin-types/index';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { GET_SECURITY_GROUPS_PATH, GET_SECURITY_ROLES_PATH, GroupsService } from './groups.service';
+
+describe('GroupsService', () => {
+  let service: GroupsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    service = TestBed.inject(GroupsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getGroupsAndRoles', () => {
+    it('should return an object with groups and roles', () => {
+      const mockSecurityGroups = [
+        {
+          id: 1,
+          name: 'Judiciary',
+          description: 'Judiciary group',
+          security_role_id: 1,
+        },
+        {
+          id: 2,
+          name: 'Opus Transcribers',
+          description: 'Opus Transcribers group',
+          security_role_id: 2,
+        },
+      ];
+
+      const mockSecurityRoles = [
+        {
+          id: 1,
+          display_name: 'Approver',
+          display_state: true,
+        },
+        {
+          id: 2,
+          display_name: 'Requestor',
+          display_state: false,
+        },
+      ];
+
+      const expectedSecurityGroups = [
+        {
+          id: 1,
+          name: 'Judiciary',
+          description: 'Judiciary group',
+          securityRoleId: 1,
+          role: { id: 1, name: 'Approver', displayState: true },
+        },
+        {
+          id: 2,
+          name: 'Opus Transcribers',
+          description: 'Opus Transcribers group',
+          securityRoleId: 2,
+          role: { id: 2, name: 'Requestor', displayState: false },
+        },
+      ];
+
+      const expectedSecurityRoles = [
+        {
+          id: 1,
+          name: 'Approver',
+          displayState: true,
+        },
+        {
+          id: 2,
+          name: 'Requestor',
+          displayState: false,
+        },
+      ];
+
+      let result!: { groups: SecurityGroup[]; roles: SecurityRole[] };
+
+      service.getGroupsAndRoles().subscribe((security) => {
+        result = security;
+      });
+
+      const groupsReq = httpMock.expectOne(GET_SECURITY_GROUPS_PATH);
+      expect(groupsReq.request.method).toEqual('GET');
+      groupsReq.flush(mockSecurityGroups);
+
+      const rolesReq = httpMock.expectOne(GET_SECURITY_ROLES_PATH);
+      expect(rolesReq.request.method).toEqual('GET');
+      rolesReq.flush(mockSecurityRoles);
+
+      expect(result.groups).toEqual(expectedSecurityGroups);
+      expect(result.roles).toEqual(expectedSecurityRoles);
+    });
+  });
+
+  describe('getGroups', () => {
+    it('should return an array of mapped SecurityGroups', () => {
+      const mockSecurityGroups = [
+        {
+          id: 1,
+          name: 'Judiciary',
+          description: 'Judiciary group',
+          security_role_id: 1,
+        },
+        {
+          id: 2,
+          name: 'Opus Transcribers',
+          description: 'Opus Transcribers group',
+          security_role_id: 2,
+        },
+      ];
+
+      const expectedSecurityGroups = [
+        {
+          id: 1,
+          name: 'Judiciary',
+          description: 'Judiciary group',
+          securityRoleId: 1,
+        },
+        {
+          id: 2,
+          name: 'Opus Transcribers',
+          description: 'Opus Transcribers group',
+          securityRoleId: 2,
+        },
+      ];
+
+      let result;
+
+      service.getGroups().subscribe((groups) => {
+        result = groups;
+      });
+
+      const req = httpMock.expectOne(GET_SECURITY_GROUPS_PATH);
+      expect(req.request.method).toEqual('GET');
+      req.flush(mockSecurityGroups);
+
+      expect(result).toEqual(expectedSecurityGroups);
+    });
+  });
+
+  describe('getRoles', () => {
+    it('should return an array of mapped SecurityRoles', () => {
+      const mockSecurityRoles = [
+        {
+          id: 1,
+          display_name: 'Approver',
+          display_state: true,
+        },
+        {
+          id: 2,
+          display_name: 'Requestor',
+          display_state: true,
+        },
+        {
+          id: 3,
+          display_name: 'Test Role',
+          display_state: false,
+        },
+      ];
+
+      const expectedSecurityRoles = [
+        {
+          id: 1,
+          name: 'Approver',
+          displayState: true,
+        },
+        {
+          id: 2,
+          name: 'Requestor',
+          displayState: true,
+        },
+        {
+          id: 3,
+          name: 'Test Role',
+          displayState: false,
+        },
+      ];
+
+      let result;
+
+      service.getRoles().subscribe((roles) => {
+        result = roles;
+      });
+
+      const req = httpMock.expectOne(GET_SECURITY_ROLES_PATH);
+      expect(req.request.method).toEqual('GET');
+      req.flush(mockSecurityRoles);
+
+      expect(result).toEqual(expectedSecurityRoles);
+    });
+  });
+});

--- a/src/app/admin/services/groups/groups.service.ts
+++ b/src/app/admin/services/groups/groups.service.ts
@@ -1,0 +1,59 @@
+import { SecurityGroup, SecurityGroupData, SecurityRole, SecurityRoleData } from '@admin-types/index';
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map, switchMap } from 'rxjs';
+
+export const GET_SECURITY_ROLES_PATH = 'api/admin/security-roles';
+export const GET_SECURITY_GROUPS_PATH = 'api/admin/security-groups';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupsService {
+  http = inject(HttpClient);
+
+  getGroupsAndRoles(): Observable<{ groups: SecurityGroup[]; roles: SecurityRole[] }> {
+    return this.getGroups().pipe(
+      switchMap((groups) => {
+        return this.getRoles().pipe(
+          map((roles) => ({
+            groups: this.mapGroupsToRoles(groups, roles),
+            roles,
+          }))
+        );
+      })
+    );
+  }
+
+  getGroups(): Observable<SecurityGroup[]> {
+    return this.http.get<SecurityGroupData[]>(GET_SECURITY_GROUPS_PATH).pipe(
+      map((groups) => {
+        return groups.map((group) => ({
+          id: group.id,
+          name: group.name,
+          description: group.description,
+          securityRoleId: group.security_role_id,
+        }));
+      })
+    );
+  }
+
+  getRoles(): Observable<SecurityRole[]> {
+    return this.http.get<SecurityRoleData[]>(GET_SECURITY_ROLES_PATH).pipe(
+      map((roles) => {
+        return roles.map((role) => ({
+          id: role.id,
+          name: role.display_name,
+          displayState: role.display_state,
+        }));
+      })
+    );
+  }
+
+  mapGroupsToRoles(groups: SecurityGroup[], roles: SecurityRole[]): SecurityGroup[] {
+    return groups.map((group) => {
+      const role = roles.find((r) => r.id === group.securityRoleId);
+      return { ...group, role };
+    });
+  }
+}

--- a/src/app/admin/services/user-admin/user-admin.service.spec.ts
+++ b/src/app/admin/services/user-admin/user-admin.service.spec.ts
@@ -2,10 +2,11 @@ import { CreateUpdateUserFormValues } from '@admin-types/index';
 import { UserData } from '@admin-types/users/user-data.interface';
 import { UserSearchFormValues } from '@admin-types/users/user-search-form-values.type';
 import { User } from '@admin-types/users/user.type';
-import { DatePipe } from '@angular/common';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
+import { GroupsService } from '@services/groups/groups.service';
 import { DateTime } from 'luxon';
+import { of } from 'rxjs';
 import { USER_ADMIN_PATH, USER_ADMIN_SEARCH_PATH, UserAdminService } from './user-admin.service';
 
 export const ADMIN_GET_USER = 'api/admin/users';
@@ -15,9 +16,41 @@ export const ADMIN_GET_SECURITY_ROLES = 'api/admin/security-roles';
 describe('UserAdminService', () => {
   let service: UserAdminService;
   let httpMock: HttpTestingController;
+  const mockSecurityGroups = [
+    {
+      id: 1,
+      name: 'Judiciary',
+      description: '',
+      securityRoleId: 1,
+      role: {
+        id: 1,
+        name: 'Approver',
+        displayState: true,
+      },
+    },
+    {
+      id: 2,
+      name: 'Opus Transcribers',
+      description: '',
+      securityRoleId: 2,
+      role: {
+        id: 2,
+        name: 'Requestor',
+        displayState: true,
+      },
+    },
+  ];
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [HttpClientTestingModule], providers: [DatePipe] });
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: GroupsService,
+          useValue: { getGroupsAndRoles: jest.fn().mockReturnValue(of({ groups: mockSecurityGroups, roles: [] })) },
+        },
+      ],
+    });
     service = TestBed.inject(UserAdminService);
     httpMock = TestBed.inject(HttpTestingController);
   });
@@ -30,9 +63,8 @@ describe('UserAdminService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('get and map user', () => {
-    it('should fetch user', () => {
-      let result!: User;
+  describe('getUser', () => {
+    it('should fetch and map user', () => {
       const mockUserId = 1;
       const mockUserData: UserData = {
         id: mockUserId,
@@ -56,59 +88,14 @@ describe('UserAdminService', () => {
         description: 'A test user',
         active: true,
         securityGroupIds: [1, 2],
-        securityGroups: [
-          {
-            id: 1,
-            name: 'Judiciary',
-            securityRoleId: 1,
-            role: {
-              id: 1,
-              name: 'Approver',
-              displayState: true,
-            },
-          },
-          {
-            id: 2,
-            name: 'Opus Transcribers',
-            securityRoleId: 2,
-            role: {
-              id: 2,
-              name: 'Requestor',
-              displayState: true,
-            },
-          },
-        ],
+        securityGroups: mockSecurityGroups,
       };
+
+      let result!: User;
 
       service.getUser(mockUserId).subscribe((res) => (result = res));
 
       httpMock.expectOne(`${ADMIN_GET_USER}/${mockUserId}`).flush(mockUserData);
-
-      httpMock.expectOne(ADMIN_GET_SECURITY_GROUPS).flush([
-        {
-          id: 1,
-          name: 'Judiciary',
-          security_role_id: 1,
-        },
-        {
-          id: 2,
-          name: 'Opus Transcribers',
-          security_role_id: 2,
-        },
-      ]);
-
-      httpMock.expectOne(ADMIN_GET_SECURITY_ROLES).flush([
-        {
-          id: 1,
-          display_name: 'Approver',
-          display_state: true,
-        },
-        {
-          id: 2,
-          display_name: 'Requestor',
-          display_state: true,
-        },
-      ]);
 
       expect(result).toEqual(mappedUser);
     });
@@ -243,100 +230,6 @@ describe('UserAdminService', () => {
         req.flush(mockUserData);
         expect(result).toBe(false);
       }));
-    });
-  });
-
-  describe('getSecurityGroups', () => {
-    it('should return an array of mapped SecurityGroups', () => {
-      const mockSecurityGroups = [
-        {
-          id: 1,
-          name: 'Judiciary',
-          security_role_id: 1,
-        },
-        {
-          id: 2,
-          name: 'Opus Transcribers',
-          security_role_id: 2,
-        },
-      ];
-
-      const expectedSecurityGroups = [
-        {
-          id: 1,
-          name: 'Judiciary',
-          securityRoleId: 1,
-        },
-        {
-          id: 2,
-          name: 'Opus Transcribers',
-          securityRoleId: 2,
-        },
-      ];
-
-      let result;
-
-      service.getSecurityGroups().subscribe((groups) => {
-        result = groups;
-      });
-
-      const req = httpMock.expectOne(ADMIN_GET_SECURITY_GROUPS);
-      expect(req.request.method).toEqual('GET');
-      req.flush(mockSecurityGroups);
-
-      expect(result).toEqual(expectedSecurityGroups);
-    });
-  });
-
-  describe('getSecurityRoles', () => {
-    it('should return an array of mapped SecurityRoles', () => {
-      const mockSecurityRoles = [
-        {
-          id: 1,
-          display_name: 'Approver',
-          display_state: true,
-        },
-        {
-          id: 2,
-          display_name: 'Requestor',
-          display_state: true,
-        },
-        {
-          id: 3,
-          display_name: 'Test Role',
-          display_state: false,
-        },
-      ];
-
-      const expectedSecurityRoles = [
-        {
-          id: 1,
-          name: 'Approver',
-          displayState: true,
-        },
-        {
-          id: 2,
-          name: 'Requestor',
-          displayState: true,
-        },
-        {
-          id: 3,
-          name: 'Test Role',
-          displayState: false,
-        },
-      ];
-
-      let result;
-
-      service.getSecurityRoles().subscribe((roles) => {
-        result = roles;
-      });
-
-      const req = httpMock.expectOne(ADMIN_GET_SECURITY_ROLES);
-      expect(req.request.method).toEqual('GET');
-      req.flush(mockSecurityRoles);
-
-      expect(result).toEqual(expectedSecurityRoles);
     });
   });
 });


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2278](https://tools.hmcts.net/jira/browse/DMP-2278)

### Change description ###

- Add groups admin screen
- Filter by group name or role
- Moved getGroups and getRoles from UserAdminService to GroupsService
- Created a getGroupsAndRoles call to retrieve both groups and roles and map them together
- Add description property to SecurityGroup type
