### PR TITLE
DMP-2711: Fix button event handler in group and user forms

### DIFF
--- a/src/app/admin/components/groups/group-form/group-form.component.html
+++ b/src/app/admin/components/groups/group-form/group-form.component.html
@@ -84,7 +84,9 @@
   </div>
 
   <div class="govuk-form-group">
-    <button class="govuk-button" type="submit">{{ isEdit ? 'Save changes' : 'Create group' }}</button>
+    <button class="govuk-button" type="submit" (mousedown)="(false)">
+      {{ isEdit ? 'Save changes' : 'Create group' }}
+    </button>
     <a class="govuk-button govuk-button--secondary" href="javascript:void(0)" (click)="onCancel()">Cancel</a>
   </div>
 </form>

--- a/src/app/admin/components/users/create-user/create-update-user-form/create-update-user-form.component.html
+++ b/src/app/admin/components/users/create-user/create-update-user-form/create-update-user-form.component.html
@@ -45,7 +45,9 @@
   </div>
 
   <div class="govuk-button-group">
-    <button class="govuk-button" type="submit">{{ this.updateUser ? 'Save changes' : 'Continue' }}</button>
+    <button class="govuk-button" type="submit" (mousedown)="(false)">
+      {{ this.updateUser ? 'Save changes' : 'Continue' }}
+    </button>
     <a class="govuk-link" href="javascript:void(0)" (click)="onCancel()">Cancel</a>
   </div>
 </form>


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2711](https://tools.hmcts.net/jira/browse/DMP-2711)

### Change description ###

Validation error messages movin submit button down when clicking preventing the onSave() firing.

Add `(mousedown)="(false)"` to submit button on form to prevent the blur event from moving the button.

More info here:
https://stackoverflow.com/questions/48011167/click-handler-is-not-triggered-when-target-element-has-been-moved