### PR TITLE
DMP-2638 Refresh UserState on each route change

### DIFF
--- a/darts-api-stub/admin/courthouses/courthouses.js
+++ b/darts-api-stub/admin/courthouses/courthouses.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { localArray } = require('../../localArray');
 const { SUPER_ADMIN } = require('../../roles');
-const { userIdhasAnyRoles } = require('../../users');
+const { userIdHasAnyRoles } = require('../../users');
 const { DateTime } = require('luxon');
 
 const router = express.Router();
@@ -186,7 +186,7 @@ const getCourthouseByCourthouseId = (courthouseId) => {
 };
 
 router.get('/:courthouseId', (req, res) => {
-  if (!userIdhasAnyRoles([SUPER_ADMIN], req.headers.user_id))
+  if (!userIdHasAnyRoles([SUPER_ADMIN], req.headers.user_id))
     return res.status(403).send({
       detail: `You do not have permission`,
     });
@@ -196,7 +196,7 @@ router.get('/:courthouseId', (req, res) => {
 });
 
 router.patch('/:courthouseId', (req, res) => {
-  if (!userIdhasAnyRoles([SUPER_ADMIN], req.headers.user_id))
+  if (!userIdHasAnyRoles([SUPER_ADMIN], req.headers.user_id))
     return res.status(403).send({
       detail: `You do not have permission`,
     });
@@ -229,7 +229,7 @@ router.patch('/:courthouseId', (req, res) => {
 
 router.post('/', (req, res) => {
   const mandatoryKeys = ['courthouse_name', 'display_name'];
-  if (!userIdhasAnyRoles([SUPER_ADMIN], req.headers.user_id))
+  if (!userIdHasAnyRoles([SUPER_ADMIN], req.headers.user_id))
     return res.status(403).send({
       detail: `You do not have permission`,
     });

--- a/darts-api-stub/admin/regions/regions.js
+++ b/darts-api-stub/admin/regions/regions.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { userIdhasAnyRoles } = require('../../users');
+const { userIdHasAnyRoles } = require('../../users');
 const { SUPER_ADMIN } = require('../../roles');
 
 const router = express.Router();
@@ -14,7 +14,7 @@ const defaultRegions = [
 ];
 
 router.get('/', (req, res) => {
-  if (!userIdhasAnyRoles([SUPER_ADMIN], req.headers.user_id))
+  if (!userIdHasAnyRoles([SUPER_ADMIN], req.headers.user_id))
     return res.status(403).send({
       detail: `You do not have permission`,
     });

--- a/darts-api-stub/admin/retention-policies/retention-policies.js
+++ b/darts-api-stub/admin/retention-policies/retention-policies.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { userIdhasAnyRoles } = require('../../users');
+const { userIdHasAnyRoles } = require('../../users');
 const { SUPER_ADMIN } = require('../../roles');
 
 const router = express.Router();
@@ -37,7 +37,7 @@ const retentionPolicies = [
 ];
 
 router.get('/', (req, res) => {
-  if (!userIdhasAnyRoles([SUPER_ADMIN], req.headers.user_id))
+  if (!userIdHasAnyRoles([SUPER_ADMIN], req.headers.user_id))
     return res.status(403).send({
       detail: `You do not have permission`,
     });

--- a/darts-api-stub/annotations/annotations.js
+++ b/darts-api-stub/annotations/annotations.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { localArray } = require('../localArray');
 const path = require('path');
-const { userIdhasAnyRoles } = require('../users');
+const { userIdHasAnyRoles } = require('../users');
 const { SUPER_ADMIN, JUDGE } = require('../roles');
 
 const router = express.Router();
@@ -54,7 +54,7 @@ router.get('/:annotationId/documents/:annotationDocumentId', (req, res) => {
 
 router.delete('/:annotationId', (req, res) => {
   const { annotationId } = req.params;
-  if (!userIdhasAnyRoles([SUPER_ADMIN, JUDGE], req.headers.user_id)) {
+  if (!userIdHasAnyRoles([SUPER_ADMIN, JUDGE], req.headers.user_id)) {
     res.status(403).send({
       detail: `You do not have permission to delete annotation with annotationId ${req.params?.annotationId}'.`,
     });

--- a/darts-api-stub/authentication/userstate.js
+++ b/darts-api-stub/authentication/userstate.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const { getUserById } = require('../users');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  const user = getUserById(parseInt(req.headers.user_id, 10));
+  if (!user) {
+    return res.status(401).send();
+  }
+  res.send(user.userState);
+});
+
+module.exports = router;

--- a/darts-api-stub/index.js
+++ b/darts-api-stub/index.js
@@ -22,6 +22,7 @@ app.get('/', (_, res) => res.send('Welcome to the DARTS API stub'));
 // stub out user authentication
 app.use('/external-user', require('./authentication'));
 app.use('/internal-user', require('./authentication'));
+app.use('/userstate', require('./authentication/userstate'));
 // stub out courthouses api
 app.use('/courthouses', require('./courthouses/courthouses'));
 // retention APIs

--- a/darts-api-stub/retentions/retention.js
+++ b/darts-api-stub/retentions/retention.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const { localArray } = require('../localArray');
 const { getEarliestDatefromKey, getLatestDatefromKey } = require('../utils/date');
 const { JUDGE, SUPER_ADMIN } = require('../roles');
-const { userIdhasAnyRoles, getUserNamebyUserId } = require('../users');
+const { userIdHasAnyRoles, getUserNameByUserId } = require('../users');
 
 const dateFormat = 'yyyy-MM-dd';
 const defaultRetentionHistory = [
@@ -123,7 +123,7 @@ router.post('', (req, res) => {
         ).startOf('day');
         if (
           retention.retention_date < latestRetentionDate &&
-          !userIdhasAnyRoles([SUPER_ADMIN, JUDGE], req.headers.user_id)
+          !userIdHasAnyRoles([SUPER_ADMIN, JUDGE], req.headers.user_id)
         ) {
           // If date is less than the latest retention date and user is not Admin or Judge
           res.status(403).send({
@@ -153,7 +153,7 @@ router.post('', (req, res) => {
       retention.case_id = parseInt(req.body.case_id);
       retention.retention_last_changed_date = DateTime.now().toISO({ setZone: true });
       // Work out which user made the request by the user ID in the headers
-      retention.amended_by = getUserNamebyUserId(req.headers.user_id);
+      retention.amended_by = getUserNameByUserId(req.headers.user_id);
       retention.retention_policy_applied = req.body?.is_permanent_retention ? 'Permanent' : 'Manual';
       retention.comments = req.body.comments;
       retention.status = 'COMPLETE';

--- a/darts-api-stub/users.js
+++ b/darts-api-stub/users.js
@@ -113,23 +113,30 @@ const stubUsers = [
   },
 ];
 
+const getUserById = (userId) => stubUsers.find((user) => user.userState.userId === userId);
+
 const getRolesByUserId = (userId) => {
-  const u = stubUsers.find((user) => user.userState.userId === userId);
-  return u?.userState.roles;
+  return getUserById(parseInt(userId, 10))?.userState.roles;
 };
 
-const userIdhasAnyRoles = (roles, userId) => {
+const userIdHasAnyRoles = (roles, userId) => {
   // If user id has any of these roles
-  const user = stubUsers.find((user) => user.userState.userId == userId);
+  const user = getUserById(parseInt(userId, 10));
   if (!user) return false;
   return user.userState.roles.some((role) => roles.includes(role));
 };
 
-const getUserNamebyUserId = (userId) => {
+const getUserNameByUserId = (userId) => {
   // If user id has any of these roles
-  const user = stubUsers.find((user) => user.userState.userId == userId);
+  const user = getUserById(parseInt(userId, 10));
   if (!user) return false;
   return user.name;
 };
 
-module.exports = { stubUsers, userIdhasAnyRoles, getUserNamebyUserId, getRolesByUserId };
+module.exports = {
+  stubUsers,
+  getUserById,
+  userIdHasAnyRoles,
+  getUserNameByUserId,
+  getRolesByUserId,
+};

--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -1,8 +1,38 @@
+import axios, { AxiosError } from 'axios';
+import config from 'config';
 import * as express from 'express';
 import { Router, Request, Response } from 'express';
+
+async function postRefreshUserState(req: Request, res: Response) {
+  if (!req.session.securityToken) {
+    return res.status(401).send();
+  }
+
+  const accessToken = req.session.securityToken.accessToken;
+  const userId = req.session.securityToken.userState?.userId;
+  try {
+    const result = await axios(`${config.get('darts-api.url')}/userstate`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        user_id: userId,
+      },
+    });
+    if (result.data && req.session.securityToken?.userState) {
+      req.session.securityToken.userState = result.data;
+    }
+    return res.json(req.session.securityToken?.userState);
+  } catch (err) {
+    console.error(`Error getting userstate from API`, err);
+    if (err instanceof AxiosError) {
+      return res.status(err.status as number).send();
+    }
+    return res.status(500).send();
+  }
+}
 
 export function init(): Router {
   const router = express.Router();
   router.get('/profile', (req: Request, res: Response) => res.json(req.session.securityToken?.userState));
+  router.post('/refresh-profile', postRefreshUserState);
   return router;
 }

--- a/src/app/core/components/app/app.component.spec.ts
+++ b/src/app/core/components/app/app.component.spec.ts
@@ -8,10 +8,12 @@ import { FooterComponent } from '../layout/footer/footer.component';
 import { HeaderComponent } from '../layout/header/header.component';
 import { AppComponent } from './app.component';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
+import { UserService } from '@services/user/user.service';
 
 describe('AppComponent', () => {
   const fakeHeaderService = { showNavigation: jest.fn() } as unknown as HeaderService;
   const fakeAppInsightsService = { logPageView: jest.fn() } as unknown as AppInsightsService;
+  const fakeUserService = { refreshUserProfile: jest.fn() } as unknown as UserService;
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
   let routerEventsSubject: Subject<NavigationEnd>;
@@ -20,6 +22,7 @@ describe('AppComponent', () => {
   beforeEach(() => {
     (fakeHeaderService.showNavigation as jest.Mock).mockClear();
     (fakeAppInsightsService.logPageView as jest.Mock).mockClear();
+    (fakeUserService.refreshUserProfile as jest.Mock).mockClear();
     routerEventsSubject = new Subject<NavigationEnd>();
 
     TestBed.configureTestingModule({
@@ -27,6 +30,7 @@ describe('AppComponent', () => {
       providers: [
         { provide: HeaderService, useValue: fakeHeaderService },
         { provide: AppInsightsService, useValue: fakeAppInsightsService },
+        { provide: UserService, useValue: fakeUserService },
         { provide: ActivatedRoute, useValue: { snapshot: mockRoute } },
       ],
     });
@@ -78,5 +82,16 @@ describe('AppComponent', () => {
     routerEventsSubject.next(navigationEndEvent);
 
     expect(fakeAppInsightsService.logPageView).toHaveBeenCalledWith(url, url);
+  });
+
+  it('should refresh user profile NavigationEnd event', () => {
+    const url = '/something';
+    jest.spyOn(fakeUserService, 'refreshUserProfile');
+    const navigationEndEvent = new NavigationEnd(1, url, url);
+
+    (TestBed.inject(Router).events as unknown as Subject<Event>).next(navigationEndEvent as Event);
+    routerEventsSubject.next(navigationEndEvent);
+
+    expect(fakeUserService.refreshUserProfile).toHaveBeenCalled();
   });
 });

--- a/src/app/core/components/app/app.component.ts
+++ b/src/app/core/components/app/app.component.ts
@@ -7,6 +7,7 @@ import { ContentComponent } from '../layout/content/content.component';
 import { FooterComponent } from '../layout/footer/footer.component';
 import { HeaderComponent } from '../layout/header/header.component';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
+import { UserService } from '@services/user/user.service';
 
 @Component({
   selector: 'app-root',
@@ -19,6 +20,7 @@ export class AppComponent implements OnInit {
   private router = inject(Router);
   private headerService = inject(HeaderService);
   private appInsightsService = inject(AppInsightsService);
+  private userService = inject(UserService);
 
   title = 'DARTS portal';
   currentUrl = '';
@@ -29,7 +31,10 @@ export class AppComponent implements OnInit {
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((e) => {
       this.currentUrl = (e as NavigationEnd).url.split('#')[0];
       this.headerService.showNavigation();
+      // log the page view with app insights
       this.appInsightsService.logPageView(this.currentUrl, this.currentUrl);
+      // refresh the user profile/userstate, including roles/permissions
+      this.userService.refreshUserProfile();
     });
   }
 }

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -4,6 +4,7 @@ import { RoleName, UserState } from '@core-types/index';
 import { shareReplay, tap } from 'rxjs';
 
 export const USER_PROFILE_PATH = '/user/profile';
+export const REFRESH_USER_PROFILE_PATH = '/user/refresh-profile';
 
 @Injectable({
   providedIn: 'root',
@@ -17,6 +18,12 @@ export class UserService {
     .get<UserState>(USER_PROFILE_PATH)
     .pipe(shareReplay(1))
     .pipe(tap((x) => this.userState.set(x)));
+
+  public refreshUserProfile(): void {
+    if (this.hasUserState()) {
+      this.http.post<UserState>(REFRESH_USER_PROFILE_PATH, null).subscribe();
+    }
+  }
 
   public isTranscriber(): boolean {
     return this.hasRole('TRANSCRIBER');
@@ -46,11 +53,15 @@ export class UserService {
     return this.hasRole('TRANSLATION_QA');
   }
 
-  private hasRole(role: RoleName): boolean {
-    return this.userState() ? this.userState()!.roles.some((x) => x.roleName === role) : false;
-  }
-
   public hasRoles(roles: RoleName[]): boolean {
     return this.userState() ? roles.some((role) => this.userState()!.roles.some((x) => x.roleName === role)) : false;
+  }
+
+  private hasUserState(): boolean {
+    return Boolean(this.userState());
+  }
+
+  private hasRole(role: RoleName): boolean {
+    return this.userState() ? this.userState()!.roles.some((x) => x.roleName === role) : false;
   }
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-2638

### Change description ###

- adding API stub for GET /userstate
- adding node server endpoint for POST /user/refresh-profile
- calling the refresh profile endpoint on navigation end, if signed in
- increasing test coverage of user.service
- renaming some functions in the users file in the stub

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
