### PR TITLE
DMP-2886: Emit error summary and clear error on save

### DIFF
--- a/src/app/admin/components/retention-policies/create-edit-retention-policy/create-edit-retention-policy.component.ts
+++ b/src/app/admin/components/retention-policies/create-edit-retention-policy/create-edit-retention-policy.component.ts
@@ -50,6 +50,7 @@ export class CreateEditRetentionPolicyComponent implements OnInit {
   }
 
   onSubmitPolicy(policy: RetentionPolicyForm) {
+    this.error = null;
     if (this.isCreate || this.isCreateRevision) {
       this.createRetentionPolicyAndRedirect(policy);
     } else {

--- a/src/app/admin/components/retention-policies/retention-policy-form/retention-policy-form.component.ts
+++ b/src/app/admin/components/retention-policies/retention-policy-form/retention-policy-form.component.ts
@@ -102,9 +102,10 @@ export class RetentionPolicyFormComponent implements OnInit, OnChanges {
     // When @Input() savePolicyError changes, set the form error
     // i.e when the server returns a 400, hightlight the offending form control
     if (changes.savePolicyError) {
-      setTimeout(() => {
+      // wrap in promise to avoid ExpressionChangedAfterItHasBeenCheckedError
+      Promise.resolve().then(() => {
         this.setFormError(this.savePolicyError!);
-      }, 0);
+      });
     }
   }
 
@@ -216,7 +217,7 @@ export class RetentionPolicyFormComponent implements OnInit, OnChanges {
     if (error === RetentionPolicyErrorCode.POLICY_START_DATE_MUST_BE_PAST) {
       this.form.controls.startDate.setErrors({ priorRevisionDate: true });
     }
-    this.form.updateValueAndValidity();
+    this.emitFormErrorSummary();
   }
 
   private emitFormErrorSummary() {


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2886](https://tools.hmcts.net/jira/browse/DMP-2886)

### Change description ###

Subsequent server-side errors are not reflected in the UI. This fix sets the error to null before a new request is made.

