### PR TITLE
DMP-2538: Add timeline component [1/2]

### DIFF
--- a/src/app/core/components/common/timeline/timeline.component.html
+++ b/src/app/core/components/common/timeline/timeline.component.html
@@ -1,0 +1,24 @@
+<div class="moj-timeline">
+  @for (item of items; track item.id) {
+    <div class="moj-timeline__item">
+      <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">{{ item.title }}</h2>
+
+        <p class="moj-timeline__byline">
+          by
+          <a class="govuk-link user-link" [routerLink]="['/admin/users', item.user.id]">{{ item.user.fullName }}</a> ({{
+            item.user.emailAddress
+          }})
+        </p>
+      </div>
+
+      <p class="moj-timeline__date">
+        <time [dateTime]="item.dateTime.toISO()">{{ item.dateTime | luxonDate: "d MMMM yyyy 'at' h:mm a" }}</time>
+      </p>
+
+      @for (line of item.descriptionLines; track line) {
+        <div class="moj-timeline__description">{{ line }}</div>
+      }
+    </div>
+  }
+</div>

--- a/src/app/core/components/common/timeline/timeline.component.spec.ts
+++ b/src/app/core/components/common/timeline/timeline.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatePipe } from '@angular/common';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { TimelineItem } from '@core-types/index';
+import { DateTime } from 'luxon';
+import { TimelineComponent } from './timeline.component';
+
+describe('TimelineComponent', () => {
+  let component: TimelineComponent;
+  let fixture: ComponentFixture<TimelineComponent>;
+
+  // 1 January 2021 at 12:00 AM
+  const time = DateTime.fromISO('2021-01-01T00:00:00Z');
+
+  const MOCK_TIMELINE_ITEMS: TimelineItem[] = [
+    {
+      dateTime: time,
+      title: 'Title 1',
+      descriptionLines: ['Description 1'],
+      id: 1,
+      user: {
+        id: 1,
+        fullName: 'Gary Smith',
+        emailAddress: 'gary@aol.com',
+      },
+    },
+    {
+      dateTime: time,
+      title: 'Title 2',
+      descriptionLines: ['Description 2'],
+      id: 2,
+      user: {
+        id: 2,
+        fullName: 'Max Payne',
+        emailAddress: 'beans@toast.com',
+      },
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TimelineComponent],
+      providers: [{ provide: ActivatedRoute, useValue: {} }, DatePipe],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimelineComponent);
+    component = fixture.componentInstance;
+    component.items = MOCK_TIMELINE_ITEMS;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders timeline items', () => {
+    const timelineItems = fixture.debugElement.queryAll(By.css('.moj-timeline__item'));
+
+    MOCK_TIMELINE_ITEMS.forEach((item, i) => {
+      const itemElement = timelineItems[i];
+      const titleElement = itemElement.query(By.css('.moj-timeline__title')).nativeElement;
+      const descriptionElement = itemElement.query(By.css('.moj-timeline__description')).nativeElement;
+      const userElement = itemElement.query(By.css('.moj-timeline__byline')).nativeElement;
+      const dateTimeElement = itemElement.query(By.css('.moj-timeline__date')).nativeElement;
+
+      expect(titleElement.textContent).toContain(item.title);
+      expect(descriptionElement.textContent).toContain(item.descriptionLines[0]);
+      expect(userElement.textContent).toContain(item.user.fullName);
+      expect(userElement.textContent).toContain(item.user.emailAddress);
+      expect(dateTimeElement.textContent).toContain('1 January 2021 at 12:00 AM');
+    });
+  });
+
+  it(`renders ${MOCK_TIMELINE_ITEMS.length} items`, () => {
+    const timelineItems = fixture.debugElement.queryAll(By.css('.moj-timeline__item'));
+    expect(timelineItems.length).toBe(MOCK_TIMELINE_ITEMS.length);
+  });
+
+  it('links to user record', () => {
+    const timelineItems = fixture.debugElement.queryAll(By.css('.moj-timeline__item'));
+    const firstItem = timelineItems[0];
+    const firstItemUserLink = firstItem.query(By.css('.user-link'));
+    expect(firstItemUserLink.nativeElement.getAttribute('href')).toBe('/admin/users/1');
+  });
+});

--- a/src/app/core/components/common/timeline/timeline.component.ts
+++ b/src/app/core/components/common/timeline/timeline.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TimelineItem } from '@core-types/index';
+import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
+
+@Component({
+  selector: 'app-timeline',
+  standalone: true,
+  imports: [LuxonDatePipe, RouterLink],
+  templateUrl: './timeline.component.html',
+  styleUrl: './timeline.component.scss',
+})
+export class TimelineComponent {
+  @Input() items: TimelineItem[] = [];
+}

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -5,5 +5,6 @@ export * from './error/error-summary-entry.interface';
 export * from './error/error-type.type';
 export * from './error/field-errors.interface';
 export * from './reporting-restriction/reporting-restriction.interface';
+export * from './timeline/timeline.type';
 export * from './user/role-name.type';
 export * from './user/user-state.interface';

--- a/src/app/core/models/timeline/timeline.type.ts
+++ b/src/app/core/models/timeline/timeline.type.ts
@@ -1,0 +1,10 @@
+import { User } from '@admin-types/index';
+import { DateTime } from 'luxon';
+
+export type TimelineItem = {
+  id: number;
+  title: string;
+  dateTime: DateTime;
+  descriptionLines: string[];
+  user: Pick<User, 'id' | 'fullName' | 'emailAddress'>;
+};

--- a/src/app/dev/dev.component.html
+++ b/src/app/dev/dev.component.html
@@ -76,5 +76,12 @@
     </div>
   </div>
 
-  <app-timeline *tab="'Timeline'" [items]="timeline" />
+  <div *tab="'Timeline'">
+    <app-timeline [items]="timeline" class="govuk-grid-column-one-half" />
+
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-s">Input</h3>
+      <pre>{{ timeline | json }}</pre>
+    </div>
+  </div>
 </app-tabs>

--- a/src/app/dev/dev.component.html
+++ b/src/app/dev/dev.component.html
@@ -75,4 +75,6 @@
       <pre>{{ checkboxes.value | json }}</pre>
     </div>
   </div>
+
+  <app-timeline *tab="'Timeline'" [items]="timeline" />
 </app-tabs>

--- a/src/app/dev/dev.component.ts
+++ b/src/app/dev/dev.component.ts
@@ -5,9 +5,12 @@ import { Router } from '@angular/router';
 import { Filter } from '@common/filters/filter.interface';
 import { FiltersComponent } from '@common/filters/filters.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
+import { TimelineComponent } from '@common/timeline/timeline.component';
+import { TimelineItem } from '@core-types/index';
 import { TabDirective } from '@directives/tab.directive';
 import { AppConfigService } from '@services/app-config/app-config.service';
 import { HeaderService } from '@services/header/header.service';
+import { DateTime } from 'luxon';
 import {
   SecurityGroupSelectorComponent,
   UserGroup,
@@ -27,6 +30,7 @@ import { CheckboxListComponent } from './../core/components/common/filters/check
     SecurityGroupSelectorComponent,
     ReactiveFormsModule,
     CheckboxListComponent,
+    TimelineComponent,
   ],
 })
 export class DevComponent implements OnInit {
@@ -137,4 +141,40 @@ export class DevComponent implements OnInit {
   // Checkbox list
   checkboxItems = [{ name: 'Approver' }, { name: 'Requester' }, { name: 'Judge' }, { name: 'Transcriber' }];
   checkboxes = new FormControl([], { nonNullable: true });
+
+  timeline: TimelineItem[] = [
+    {
+      id: 1,
+      title: 'Rejected',
+      dateTime: DateTime.now(),
+      descriptionLines: ['Comment 1 here'],
+      user: {
+        id: 1,
+        fullName: 'John Smith',
+        emailAddress: 'john@smith.com',
+      },
+    },
+    {
+      id: 2,
+      title: 'Approved',
+      dateTime: DateTime.now(),
+      descriptionLines: ['Comment 1 here', 'Comment 2 here'],
+      user: {
+        id: 2,
+        fullName: 'Jane Smith',
+        emailAddress: 'jane@smith.com',
+      },
+    },
+    {
+      id: 3,
+      title: 'Requested',
+      dateTime: DateTime.now(),
+      descriptionLines: ['Comment 1 here', 'Comment 2 here', 'Comment 3 here'],
+      user: {
+        id: 3,
+        fullName: 'John Doe',
+        emailAddress: 'john@doe.com',
+      },
+    },
+  ];
 }


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2538](https://tools.hmcts.net/jira/browse/DMP-2538)

### Change description ###

- This is 1 of 2 PRs for DMP-2538
- Add a new common timeline component
- Available at http://localhost:3000/dev/components

Wraps the [MoJ timeline component](https://design-patterns.service.justice.gov.uk/components/timeline)

<img width="1355" alt="image" src="https://github.com/hmcts/darts-portal/assets/125365979/056b149f-d00e-498c-994d-cbcd1783868e">


