### PR TITLE
DMP-2905: Mark form as touched when setting input value

### DIFF
--- a/src/app/portal/components/search/search.component.ts
+++ b/src/app/portal/components/search/search.component.ts
@@ -119,7 +119,8 @@ export class SearchComponent implements OnInit, OnDestroy {
   }
 
   setInputValue(value: string, control: string) {
-    this.form.controls[`${control}`].patchValue(value);
+    this.form.controls[control].patchValue(value);
+    this.form.controls[control].markAsTouched();
   }
 
   isControlInvalid(control: keyof SearchFormValues): boolean {


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-2905](https://tools.hmcts.net/jira/browse/DMP-2905)

### Change description ###

Marking form control as touched allows requests to be made to the server.

Steps to replicate failure not in the ticket:

1. Perform search
2. Clear search
3. Select a date from datepicker without touching the form
4. No network call made

Adding `.markAsTouched()` fixes this