### PR TITLE
Fixing the size of the admin "File deletion" heading

### DIFF
--- a/src/app/admin/components/file-deletion/file-deletion.component.html
+++ b/src/app/admin/components/file-deletion/file-deletion.component.html
@@ -1,4 +1,4 @@
-<app-govuk-heading>File deletion</app-govuk-heading>
+<app-govuk-heading tag="h1" size="xl">File deletion</app-govuk-heading>
 
 <app-tabs>
   <div *tab="'Audio files'">


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

It's now the same size as the "System configuration" heading

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
