### PR TITLE
Fixing path to assets

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -30,7 +30,7 @@ export const startServer = ({ disableAuthentication }: StartServerOptions = { di
 
   app.use(
     '/assets',
-    express.static(path.join(__dirname, './assets'), {
+    express.static(path.join(__dirname, '../assets'), {
       setHeaders: function (res) {
         // set CORS headers for assets so that they can be fetched from the Azure AD B2C login screen
         res.set('Access-Control-Allow-Origin', config.get('authentication.azureAdB2cOriginHost'));


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Due to the API stubbing, the directories in `dist` have changed. Updating the code to find the assets correctly in there.

The side-effect of this is that the azure login page (http://localhost:3000/auth/azuread-b2c-login) will not work locally, but when the stubbing is removed this can be reverted.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
