### PR TITLE
DMP-3085 : Fix API call for transcript search by specific date and remove required validation

### DIFF
--- a/src/app/admin/constants/transcript-search-form-error-messages.ts
+++ b/src/app/admin/constants/transcript-search-form-error-messages.ts
@@ -10,14 +10,12 @@ export const TranscriptSearchFormErrorMessages: Record<string, Record<string, st
     realDate: 'Enter a real date',
   },
   from: {
-    required: 'You have not selected a start date. Select a start date to define your search',
     pattern: 'You have not entered a recognised date in the correct format (for example 31/01/2023)',
     futureDate: 'You have selected a date in the future. Requested start date must be in the past',
     realDate: 'Enter a real date',
     dateRange: 'The start date must be before the end date',
   },
   to: {
-    required: 'You have not selected an end date. Select an end date to define your search',
     pattern: 'You have not entered a recognised date in the correct format (for example 31/01/2023)',
     futureDate: 'You have selected a date in the future. Requested end date must be in the past',
     realDate: 'Enter a real date',

--- a/src/app/admin/services/transcription-admin/transcription-admin.service.spec.ts
+++ b/src/app/admin/services/transcription-admin/transcription-admin.service.spec.ts
@@ -161,7 +161,7 @@ describe('TranscriptionAdminService', () => {
       expect(req.request.body).toEqual(emptySearchRequestBody);
     });
 
-    it('map specific date to requested_at_from', () => {
+    it('map specific date to requested_at_from and requested_at_to', () => {
       const formValues = {
         requestedDate: { type: 'specific', specific: '01/01/2022', from: '', to: '' },
       };
@@ -169,6 +169,7 @@ describe('TranscriptionAdminService', () => {
       const expectedBody = {
         ...emptySearchRequestBody,
         requested_at_from: '2022-01-01',
+        requested_at_to: '2022-01-01',
       };
 
       service.search(formValues).subscribe();

--- a/src/app/admin/services/transcription-admin/transcription-admin.service.ts
+++ b/src/app/admin/services/transcription-admin/transcription-admin.service.ts
@@ -177,7 +177,7 @@ export class TranscriptionAdminService {
       owner: values.owner || null,
       requested_by: values.requestedBy || null,
       requested_at_from: this.formatDate(values.requestedDate?.specific) ?? this.formatDate(values.requestedDate?.from),
-      requested_at_to: this.formatDate(values.requestedDate?.to),
+      requested_at_to: this.formatDate(values.requestedDate?.specific) ?? this.formatDate(values.requestedDate?.to),
       is_manual_transcription:
         values.requestMethod === 'all' || !values.requestMethod
           ? null

--- a/src/app/core/components/common/specific-or-range-date-picker/specific-or-range-date-picker.component.spec.ts
+++ b/src/app/core/components/common/specific-or-range-date-picker/specific-or-range-date-picker.component.spec.ts
@@ -74,18 +74,6 @@ describe('SpecificOrRangeDatePickerComponent', () => {
   });
 
   describe('Validation errors', () => {
-    it('toDateControl should be required when fromDateControl is set', () => {
-      component.dateTypeControl.setValue('range');
-      component.fromDateControl.setValue('01/01/2022');
-      expect(component.toDateControl.hasError('required')).toBe(true);
-    });
-
-    it('fromDateControl should be required when toDateControl is set', () => {
-      component.dateTypeControl.setValue('range');
-      component.toDateControl.setValue('01/01/2022');
-      expect(component.fromDateControl.hasError('required')).toBe(true);
-    });
-
     it('dates should not be in the future', () => {
       component.specificDateControl.setValue('01/01/3000');
       expect(component.specificDateControl.hasError('futureDate')).toBe(true);

--- a/src/app/core/components/common/specific-or-range-date-picker/specific-or-range-date-picker.component.ts
+++ b/src/app/core/components/common/specific-or-range-date-picker/specific-or-range-date-picker.component.ts
@@ -1,7 +1,7 @@
 import { JsonPipe, NgClass, NgIf } from '@angular/common';
 import { Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ControlContainer, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ControlContainer, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { DatepickerComponent } from '@common/datepicker/datepicker.component';
 import { TranscriptSearchFormErrorMessages } from '@constants/transcript-search-form-error-messages';
 
@@ -28,8 +28,6 @@ export class SpecificOrRangeDatePickerComponent implements OnInit {
     this.form = <FormGroup>this.controlContainer.control;
     this.resetDateControlsOnDateTypeChanges();
     this.setDateRangeErrorsOnChanges();
-    this.setRequiredValidatorsOnValueChanges(this.fromDateControl, this.toDateControl);
-    this.setRequiredValidatorsOnValueChanges(this.toDateControl, this.fromDateControl);
   }
 
   get dateTypeControl() {
@@ -62,23 +60,6 @@ export class SpecificOrRangeDatePickerComponent implements OnInit {
     const errorKey = Object.keys(errors)[0];
 
     return [TranscriptSearchFormErrorMessages[controlKey][errorKey]];
-  }
-
-  private setRequiredValidatorsOnValueChanges(sourceControl: FormControl, dependantControl: FormControl) {
-    sourceControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
-      if (value) {
-        dependantControl.addValidators(Validators.required);
-      } else {
-        dependantControl.removeValidators(Validators.required);
-      }
-
-      if (dependantControl.value) {
-        sourceControl.addValidators(Validators.required);
-      }
-
-      sourceControl.updateValueAndValidity({ onlySelf: true, emitEvent: false });
-      dependantControl.updateValueAndValidity({ onlySelf: true, emitEvent: false });
-    });
   }
 
   private setDateRangeErrorsOnChanges() {


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3085](https://tools.hmcts.net/jira/browse/DMP-3085)

### Change description ###

- Remove optional required field for transcript search
- map specific date to both 'from' and 'to' to constrain search results