### PR TITLE
DMP-3100 & DMP-3101: Add search for completed transcript documents

### DIFF
--- a/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
@@ -154,4 +154,22 @@ describe('Admin - Transcript requests', () => {
       cy.get('app-govuk-banner').contains('Status updated');
     });
   });
+
+  describe('Search completed transcripts', () => {
+    it('searches for completed transcripts', () => {
+      cy.get('a').contains('Completed transcripts').click();
+      cy.get('button').contains('Search').click();
+      cy.get('app-search-completed-transcripts-results').contains('C0001');
+      cy.get('app-search-completed-transcripts-results').contains('Cardiff');
+      cy.get('app-search-completed-transcripts-results').contains('01 Jan 2021');
+      cy.get('app-search-completed-transcripts-results').contains('Manual');
+    });
+
+    it('redirects to transcript on 1 result', () => {
+      cy.get('a').contains('Completed transcripts').click();
+      cy.get('#caseId').clear().type('C0001');
+      cy.get('button').contains('Search').click();
+      cy.url().should('include', '/admin/transcripts/document/0');
+    });
+  });
 });

--- a/darts-api-stub/admin/transcriptions/transcription-documents.js
+++ b/darts-api-stub/admin/transcriptions/transcription-documents.js
@@ -1,0 +1,71 @@
+const router = require('express').Router();
+
+const documents = [
+  {
+    transcription_document_id: 0,
+    transcription_id: 0,
+    case: {
+      id: 0,
+      case_number: 'C0001',
+    },
+    courthouse: {
+      id: 0,
+      display_name: 'Cardiff',
+    },
+    hearing: {
+      id: 0,
+      hearing_date: '2021-01-01',
+    },
+    is_manual_transcription: true,
+    is_hidden: false,
+  },
+  {
+    transcription_document_id: 1,
+    transcription_id: 1,
+    case: {
+      id: 1,
+      case_number: 'C0002',
+    },
+    courthouse: {
+      id: 1,
+      display_name: 'Swansea',
+    },
+    hearing: {
+      id: 1,
+      hearing_date: '2022-02-02',
+    },
+    is_manual_transcription: false,
+    is_hidden: false,
+  },
+  {
+    transcription_document_id: 2,
+    transcription_id: 2,
+    case: {
+      id: 2,
+      case_number: 'C0003',
+    },
+    courthouse: {
+      id: 2,
+      display_name: 'Newport',
+    },
+    hearing: {
+      id: 2,
+      hearing_date: '2023-03-03',
+    },
+    is_manual_transcription: true,
+    is_hidden: true,
+  },
+];
+
+router.post('/search', (req, res) => {
+  const { case_number } = req.body;
+  if (case_number) {
+    const filteredDocuments = documents.filter((document) => document.case.case_number === case_number);
+    res.send(filteredDocuments);
+    return;
+  }
+
+  res.send(documents);
+});
+
+module.exports = router;

--- a/darts-api-stub/index.js
+++ b/darts-api-stub/index.js
@@ -49,6 +49,7 @@ app.use('/admin/retention-policy-types', require('./admin/retention-policies/ret
 app.use('/admin/transcriptions', require('./admin/transcriptions/transcriptions'));
 app.use('/admin/transcription-status', require('./admin/transcriptions/transcription-status').router);
 app.use('/admin/transcription-workflows', require('./admin/transcriptions/transcription-workflows'));
+app.use('/admin/transcription-documents', require('./admin/transcriptions/transcription-documents'));
 app.use('/admin/automated-tasks', require('./admin/automated-tasks/automated-tasks'));
 app.use('/admin/event-mappings', require('./admin/event-mappings/event-mappings'));
 app.use('/admin/event-handlers', require('./admin/event-mappings/event-handlers'));

--- a/src/app/admin/admin.routes.ts
+++ b/src/app/admin/admin.routes.ts
@@ -158,6 +158,30 @@ export const ADMIN_ROUTES: Routes = [
     loadComponent: () => import('./components/transcripts/transcripts.component').then((c) => c.TranscriptsComponent),
   },
   {
+    path: 'admin/transcripts/:transcriptionId',
+    title: 'DARTS Admin View Transcription',
+    loadComponent: () =>
+      import('./components/transcripts/view-transcript/view-transcript.component').then(
+        (c) => c.ViewTranscriptComponent
+      ),
+  },
+  {
+    path: 'admin/transcripts/:transcriptionId/change-status',
+    title: 'DARTS Admin Change Transcription Status',
+    loadComponent: () =>
+      import('./components/transcripts/change-transcript-status/change-transcript-status.component').then(
+        (c) => c.ChangeTranscriptStatusComponent
+      ),
+  },
+  {
+    path: 'admin/transcripts/document/:transcriptionDocumentId',
+    title: 'DARTS Admin View Transcription Document',
+    loadComponent: () =>
+      import('./components/transcripts/view-transcription-document/view-transcription-document.component').then(
+        (c) => c.ViewTranscriptionDocumentComponent
+      ),
+  },
+  {
     path: 'admin/file-deletion',
     title: 'DARTS Admin File Deletion',
     loadComponent: () =>
@@ -234,22 +258,6 @@ export const ADMIN_ROUTES: Routes = [
       import(
         './components/retention-policies/create-edit-retention-policy/create-edit-retention-policy.component'
       ).then((c) => c.CreateEditRetentionPolicyComponent),
-  },
-  {
-    path: 'admin/transcripts/:transcriptionId',
-    title: 'DARTS Admin View Transcription',
-    loadComponent: () =>
-      import('./components/transcripts/view-transcript/view-transcript.component').then(
-        (c) => c.ViewTranscriptComponent
-      ),
-  },
-  {
-    path: 'admin/transcripts/:transcriptionId/change-status',
-    title: 'DARTS Admin Change Transcription Status',
-    loadComponent: () =>
-      import('./components/transcripts/change-transcript-status/change-transcript-status.component').then(
-        (c) => c.ChangeTranscriptStatusComponent
-      ),
   },
 ].map((route) => ({
   ...route,

--- a/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.html
+++ b/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.html
@@ -1,0 +1,12 @@
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+<app-data-table [rows]="rows" [columns]="columns" caption="Transcript search results" [hiddenCaption]="true">
+  <ng-template [tableRowTemplate]="rows" let-row>
+    <td class="govuk-table__cell">
+      <a href="#" class="govuk-link" [routerLink]="['document', row.id]"> {{ row.id }}</a>
+    </td>
+    <td class="govuk-table__cell">{{ row.caseNumber }}</td>
+    <td class="govuk-table__cell">{{ row.courthouse }}</td>
+    <td class="govuk-table__cell">{{ row.hearingDate | luxonDate: 'dd MMM yyyy' }}</td>
+    <td class="govuk-table__cell">{{ row.requestMethod ? 'Manual' : 'Automatic' }}</td>
+  </ng-template>
+</app-data-table>

--- a/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.spec.ts
+++ b/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TranscriptionDocument } from '@admin-types/index';
+import { DateTime } from 'luxon';
+import { SearchCompletedTranscriptsResultsComponent } from './search-completed-transcripts-results.component';
+
+describe('SearchCompletedTranscriptsResultsComponent', () => {
+  let component: SearchCompletedTranscriptsResultsComponent;
+  let fixture: ComponentFixture<SearchCompletedTranscriptsResultsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchCompletedTranscriptsResultsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchCompletedTranscriptsResultsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnChanges', () => {
+    it('should call mapRows', () => {
+      jest.spyOn(component, 'mapRows');
+      component.ngOnChanges();
+      expect(component.mapRows).toHaveBeenCalled();
+    });
+  });
+
+  describe('mapRows', () => {
+    it('should return an array of objects with the correct properties', () => {
+      const results: TranscriptionDocument[] = [
+        {
+          transcriptionDocumentId: 1,
+          case: { id: 1, caseNumber: 'caseNumber' },
+          courthouse: { id: 1, displayName: 'courthouse' },
+          hearing: { id: 1, hearingDate: DateTime.fromISO('2021-01-01') },
+          isManualTranscription: true,
+          transcriptionId: 0,
+          isHidden: false,
+        },
+      ];
+      const expected = [
+        {
+          id: 1,
+          caseNumber: 'caseNumber',
+          courthouse: 'courthouse',
+          hearingDate: DateTime.fromISO('2021-01-01'),
+          requestMethod: true,
+        },
+      ];
+      expect(component.mapRows(results)).toEqual(expected);
+    });
+  });
+});

--- a/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.ts
+++ b/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.ts
@@ -1,0 +1,42 @@
+import { TranscriptionDocument } from '@admin-types/transcription';
+import { Component, Input, OnChanges } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { DataTableComponent } from '@common/data-table/data-table.component';
+import { DatatableColumn } from '@core-types/index';
+import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
+
+@Component({
+  selector: 'app-search-completed-transcripts-results',
+  standalone: true,
+  imports: [DataTableComponent, TableRowTemplateDirective, RouterLink, LuxonDatePipe],
+  templateUrl: './search-completed-transcripts-results.component.html',
+  styleUrl: './search-completed-transcripts-results.component.scss',
+})
+export class SearchCompletedTranscriptsResultsComponent implements OnChanges {
+  @Input() results: TranscriptionDocument[] = [];
+
+  rows: ReturnType<typeof this.mapRows> = [];
+
+  columns: DatatableColumn[] = [
+    { name: 'Transcript ID', prop: 'id', sortable: true },
+    { name: 'Case ID', prop: 'caseNumber', sortable: true },
+    { name: 'Courthouse', prop: 'courthouse', sortable: true },
+    { name: 'Hearing Date', prop: 'hearingDate', sortable: true },
+    { name: 'Request Method', prop: 'requestMethod', sortable: true },
+  ];
+
+  ngOnChanges() {
+    this.rows = this.mapRows(this.results);
+  }
+
+  mapRows(results: TranscriptionDocument[]) {
+    return results.map((result) => ({
+      id: result.transcriptionDocumentId,
+      caseNumber: result.case.caseNumber,
+      courthouse: result.courthouse.displayName,
+      hearingDate: result.hearing.hearingDate,
+      requestMethod: result.isManualTranscription,
+    }));
+  }
+}

--- a/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.html
+++ b/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.html
@@ -1,29 +1,40 @@
 <form [formGroup]="form" (ngSubmit)="onSubmit()">
-  <div class="govuk-form-group">
-    <label class="govuk-label" for="requestId"> Request ID </label>
-    <input
-      formControlName="requestId"
-      class="govuk-input govuk-input--width-20"
-      id="requestId"
-      name="requestId"
-      type="text"
-    />
-  </div>
+  @if (isCompletedTranscriptSearch) {
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="caseId"> Case ID </label>
+      <input formControlName="caseId" class="govuk-input govuk-input--width-20" id="caseId" name="caseId" type="text" />
+    </div>
+  } @else {
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="requestId"> Request ID </label>
+      <input
+        formControlName="requestId"
+        class="govuk-input govuk-input--width-20"
+        id="requestId"
+        name="requestId"
+        type="text"
+      />
+    </div>
+  }
+
   <details class="govuk-details" [open]="isAdvancedSearch">
     <summary class="govuk-details__summary" (click)="$event.preventDefault(); toggleAdvancedSearch()">
       <span class="govuk-details__summary-text"> Advanced search </span>
     </summary>
     <div class="govuk-details__text">
-      <div class="govuk-form-group">
-        <label class="govuk-label" for="caseId"> Case ID </label>
-        <input
-          formControlName="caseId"
-          class="govuk-input govuk-input--width-20"
-          id="caseId"
-          name="caseId"
-          type="text"
-        />
-      </div>
+      @if (!isCompletedTranscriptSearch) {
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="caseId"> Case ID </label>
+          <input
+            formControlName="caseId"
+            class="govuk-input govuk-input--width-20"
+            id="caseId"
+            name="caseId"
+            type="text"
+          />
+        </div>
+      }
+
       <div class="govuk-form-group">
         <label class="govuk-label" for="courthouse"> Courthouse </label>
         <input

--- a/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.ts
+++ b/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.ts
@@ -1,5 +1,5 @@
 import { JsonPipe, NgIf } from '@angular/common';
-import { Component, DestroyRef, EventEmitter, Output, inject } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DatepickerComponent } from '@common/datepicker/datepicker.component';
 import { SpecificOrRangeDatePickerComponent } from '@common/specific-or-range-date-picker/specific-or-range-date-picker.component';
@@ -27,6 +27,8 @@ export class SearchTranscriptsFormComponent {
   fb = inject(FormBuilder);
   destroyRef = inject(DestroyRef);
   formService = inject(FormService);
+
+  @Input() isCompletedTranscriptSearch = false;
 
   form = this.fb.group({
     requestId: [''],

--- a/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.ts
+++ b/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.ts
@@ -1,5 +1,5 @@
 import { Transcription } from '@admin-types/index';
-import { JsonPipe, NgClass } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { Component, Input, OnChanges } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
@@ -11,13 +11,12 @@ import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 @Component({
   selector: 'app-search-transcripts-results',
   standalone: true,
-  imports: [JsonPipe, DataTableComponent, TableRowTemplateDirective, LuxonDatePipe, NgClass, RouterLink],
+  imports: [DataTableComponent, TableRowTemplateDirective, LuxonDatePipe, NgClass, RouterLink],
   templateUrl: './search-transcripts-results.component.html',
   styleUrl: './search-transcripts-results.component.scss',
 })
 export class SearchTranscriptsResultsComponent implements OnChanges {
   @Input() results: Transcription[] = [];
-  @Input() loading: boolean | null = false;
 
   columns: DatatableColumn[] = [
     { name: 'Request ID', prop: 'id', sortable: true },

--- a/src/app/admin/components/transcripts/transcripts.component.html
+++ b/src/app/admin/components/transcripts/transcripts.component.html
@@ -1,20 +1,36 @@
 <app-validation-error-summary [errors]="errors"></app-validation-error-summary>
 <app-govuk-heading size="xl">Transcripts</app-govuk-heading>
 
-<app-tabs>
-  <div *tab="'Transcript requests'">
+<app-tabs (tabChange)="clearSearch()">
+  <div *tab="'Requests'">
     <app-govuk-heading>Transcript requests</app-govuk-heading>
 
     <app-search-transcripts-form (search)="onSearch($event)" (errors)="errors = $event" />
 
-    @if (loading$ | async) {
-      <app-loading text="Loading transcript requests..." />
+    @if (results$ | async; as results) {
+      <app-search-transcripts-results [results]="results" />
     }
 
-    @if (results$ | async; as results) {
-      <app-search-transcripts-results [results]="results" [loading]="loading$ | async" />
+    @if (loading$ | async) {
+      <app-loading text="Searching transcript requests..." />
     }
   </div>
 
-  <div *tab="'Completed transcripts'"></div>
+  <div *tab="'Completed transcripts'">
+    <app-govuk-heading>Completed transcripts</app-govuk-heading>
+
+    <app-search-transcripts-form
+      [isCompletedTranscriptSearch]="true"
+      (search)="onSearch($event)"
+      (errors)="errors = $event"
+    />
+
+    @if (completedResults$ | async; as results) {
+      <app-search-completed-transcripts-results [results]="results" />
+    }
+
+    @if (loading$ | async) {
+      <app-loading text="Searching completed transcripts..." />
+    }
+  </div>
 </app-tabs>

--- a/src/app/admin/components/transcripts/transcripts.component.spec.ts
+++ b/src/app/admin/components/transcripts/transcripts.component.spec.ts
@@ -1,12 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { Transcription, TranscriptionStatus } from '@admin-types/transcription';
+import { Transcription, TranscriptionDocument, TranscriptionStatus } from '@admin-types/transcription';
 import { DatePipe } from '@angular/common';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { CourthouseData } from '@core-types/index';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import { CourthouseService } from '@services/courthouses/courthouses.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
+import { DateTime } from 'luxon';
 import { of } from 'rxjs';
 import { TranscriptsComponent } from './transcripts.component';
 
@@ -18,6 +18,45 @@ describe('TranscriptsComponent', () => {
     { id: 1, courthouse: { id: 1 }, status: { id: 1 } },
     { id: 2, courthouse: { id: 1 }, status: { id: 1 } },
   ] as Transcription[];
+
+  const MOCK_COMPLETED_SEARCH_RESULT: TranscriptionDocument[] = [
+    {
+      transcriptionDocumentId: 0,
+      transcriptionId: 0,
+      case: {
+        id: 0,
+        caseNumber: 'caseNumber',
+      },
+      courthouse: {
+        id: 0,
+        displayName: 'courthouse',
+      },
+      hearing: {
+        id: 0,
+        hearingDate: DateTime.fromISO('2021-01-01'),
+      },
+      isManualTranscription: false,
+      isHidden: false,
+    },
+    {
+      transcriptionDocumentId: 1,
+      transcriptionId: 1,
+      case: {
+        id: 1,
+        caseNumber: 'caseNumber',
+      },
+      courthouse: {
+        id: 1,
+        displayName: 'courthouse',
+      },
+      hearing: {
+        id: 1,
+        hearingDate: DateTime.fromISO('2021-01-01'),
+      },
+      isManualTranscription: true,
+      isHidden: false,
+    },
+  ];
 
   const MOCK_COURTHOUSES = of([
     {
@@ -59,6 +98,7 @@ describe('TranscriptsComponent', () => {
             getTranscriptionStatuses: jest.fn().mockReturnValue(MOCK_STATUSES),
             mapResults: jest.fn().mockReturnValue(MOCK_MAPPING),
             search: jest.fn().mockReturnValue(of(MOCK_SEARCH_RESULT)),
+            searchCompletedTranscriptions: jest.fn().mockReturnValue(of(MOCK_COMPLETED_SEARCH_RESULT)),
           },
         },
         {
@@ -110,9 +150,40 @@ describe('TranscriptsComponent', () => {
     expect(component.transcriptService.search).toHaveBeenCalledWith(searchValues);
   });
 
-  it('should clear the search when onClear is called', () => {
+  it('should map courthouses and statuses to search results', fakeAsync(() => {
+    let result;
+    component.results$.subscribe((results) => (result = results));
+
+    component.search$.next({});
+    component.isSubmitted$.next(true);
+
+    tick();
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        courthouse: {
+          id: 1,
+          displayName: 'Test display name',
+          courthouseName: 'Test courthouse name',
+        },
+        status: { id: 1, type: 'Approved', displayName: 'Approved' },
+      },
+      {
+        courthouse: {
+          id: 1,
+          displayName: 'Test display name',
+          courthouseName: 'Test courthouse name',
+        },
+        id: 2,
+        status: { id: 1, type: 'Approved', displayName: 'Approved' },
+      },
+    ]);
+  }));
+
+  it('should clear the search when clearSearch is called', () => {
     jest.spyOn(component.search$, 'next');
-    component.onClear();
+    component.clearSearch();
     expect(component.search$.next).toHaveBeenCalledWith(null);
   });
 
@@ -121,9 +192,15 @@ describe('TranscriptsComponent', () => {
     expect(component.isSubmitted$.value).toBe(true);
   });
 
-  it('should set isSubmitted to false when onClear is called', () => {
-    component.onClear();
+  it('should set isSubmitted to false when clearSearch is called', () => {
+    component.clearSearch();
     expect(component.isSubmitted$.value).toBe(false);
+  });
+
+  it('clears errors when clearSearch is called', () => {
+    component.errors = [{ fieldId: '1', message: 'error' }];
+    component.clearSearch();
+    expect(component.errors).toEqual([]);
   });
 
   it('should navigate to the transcript page if only one result is returned', () => {
@@ -132,5 +209,34 @@ describe('TranscriptsComponent', () => {
     component.search$.next({});
     component.isSubmitted$.next(true);
     expect(component.router.navigate).toHaveBeenCalledWith(['/admin/transcripts', 1]);
+  });
+
+  describe('completedResults$', () => {
+    it('should return the results when the search is completed', () => {
+      let result;
+
+      component.completedResults$.subscribe((results) => (result = results));
+
+      component.search$.next({});
+      component.isSubmitted$.next(true);
+
+      expect(result).toEqual(MOCK_COMPLETED_SEARCH_RESULT);
+    });
+
+    it('redirects to the document page if only one result is returned', () => {
+      jest.spyOn(component.router, 'navigate');
+
+      const transcriptService = TestBed.inject(TranscriptionAdminService);
+      jest
+        .spyOn(transcriptService, 'searchCompletedTranscriptions')
+        .mockReturnValue(of([MOCK_COMPLETED_SEARCH_RESULT[0]]));
+
+      component.completedResults$.subscribe();
+
+      component.search$.next({});
+      component.isSubmitted$.next(true);
+
+      expect(component.router.navigate).toHaveBeenCalledWith(['/admin/transcripts/document', 0]);
+    });
   });
 });

--- a/src/app/admin/components/transcripts/transcripts.component.spec.ts
+++ b/src/app/admin/components/transcripts/transcripts.component.spec.ts
@@ -1,7 +1,7 @@
 import { Transcription, TranscriptionDocument, TranscriptionStatus } from '@admin-types/transcription';
 import { DatePipe } from '@angular/common';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
 import { CourthouseData } from '@core-types/index';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import { CourthouseService } from '@services/courthouses/courthouses.service';
@@ -150,14 +150,15 @@ describe('TranscriptsComponent', () => {
     expect(component.transcriptService.search).toHaveBeenCalledWith(searchValues);
   });
 
-  it('should map courthouses and statuses to search results', fakeAsync(() => {
+  it('should map courthouses and statuses to search results', () => {
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
     let result;
     component.results$.subscribe((results) => (result = results));
 
     component.search$.next({});
     component.isSubmitted$.next(true);
-
-    tick();
 
     expect(result).toEqual([
       {
@@ -169,17 +170,8 @@ describe('TranscriptsComponent', () => {
         },
         status: { id: 1, type: 'Approved', displayName: 'Approved' },
       },
-      {
-        courthouse: {
-          id: 1,
-          displayName: 'Test display name',
-          courthouseName: 'Test courthouse name',
-        },
-        id: 2,
-        status: { id: 1, type: 'Approved', displayName: 'Approved' },
-      },
     ]);
-  }));
+  });
 
   it('should clear the search when clearSearch is called', () => {
     jest.spyOn(component.search$, 'next');

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.html
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.html
@@ -1,0 +1,3 @@
+<app-govuk-heading caption="Transcript file">{{ transcriptionDocumentId }}</app-govuk-heading>
+
+<p class="govuk-body">Placeholder screen to satisfy AC3 of DMP-3101</p>

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.spec.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivatedRoute } from '@angular/router';
+import { ViewTranscriptionDocumentComponent } from './view-transcription-document.component';
+
+describe('ViewTranscriptionDocumentComponent', () => {
+  let component: ViewTranscriptionDocumentComponent;
+  let fixture: ComponentFixture<ViewTranscriptionDocumentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ViewTranscriptionDocumentComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                transcriptionDocumentId: 1,
+              },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ViewTranscriptionDocumentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
@@ -1,0 +1,16 @@
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
+
+@Component({
+  selector: 'app-view-transcription-document',
+  standalone: true,
+  imports: [GovukHeadingComponent],
+  templateUrl: './view-transcription-document.component.html',
+  styleUrl: './view-transcription-document.component.scss',
+})
+export class ViewTranscriptionDocumentComponent {
+  route = inject(ActivatedRoute);
+
+  transcriptionDocumentId: string = this.route.snapshot.params.transcriptionDocumentId;
+}

--- a/src/app/admin/models/transcription/index.ts
+++ b/src/app/admin/models/transcription/index.ts
@@ -1,5 +1,7 @@
 export * from './transcription';
 export * from './transcription-data.interface';
+export * from './transcription-document';
+export * from './transcription-document-data.interface';
 export * from './transcription-search-form-values';
 export * from './transcription-search-request.interface';
 export * from './transcription-status';

--- a/src/app/admin/models/transcription/transcription-document-data.interface.ts
+++ b/src/app/admin/models/transcription/transcription-document-data.interface.ts
@@ -1,0 +1,18 @@
+export interface TranscriptionDocumentData {
+  transcription_document_id: number;
+  transcription_id: number;
+  case: {
+    id: number;
+    case_number: string;
+  };
+  courthouse: {
+    id: number;
+    display_name: string;
+  };
+  hearing: {
+    id: number;
+    hearing_date: string;
+  };
+  is_manual_transcription: boolean;
+  is_hidden: boolean;
+}

--- a/src/app/admin/models/transcription/transcription-document.ts
+++ b/src/app/admin/models/transcription/transcription-document.ts
@@ -1,0 +1,20 @@
+import { DateTime } from 'luxon';
+
+export type TranscriptionDocument = {
+  transcriptionDocumentId: number;
+  transcriptionId: number;
+  case: {
+    id: number;
+    caseNumber: string;
+  };
+  courthouse: {
+    id: number;
+    displayName: string;
+  };
+  hearing: {
+    id: number;
+    hearingDate: DateTime;
+  };
+  isManualTranscription: boolean;
+  isHidden: boolean;
+};


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3100](https://tools.hmcts.net/jira/browse/DMP-3100)
[DMP-3101](https://tools.hmcts.net/jira/browse/DMP-3101)

### Change description ###

Re-used transcript search form passing in a flag to swap case id and request id.
Temporary placeholder screen for view transcript document
