### PR TITLE
DMP-3133: Map 'Approved' status to 'With Transcriber' in portal

### DIFF
--- a/darts-api-stub/transcriptions/transcriptions.js
+++ b/darts-api-stub/transcriptions/transcriptions.js
@@ -76,6 +76,21 @@ const yourTranscriptionsStub = {
       },
       requested_ts: '2023-06-26T13:00:00Z',
     },
+    {
+      transcription_id: 6,
+      case_id: 123,
+      case_number: 'C123',
+      courthouse_name: 'Swansea',
+      hearing_date: '2023-06-10',
+      transcription_type: 'Court log',
+      status: 'Approved',
+      transcription_urgency: {
+        transcription_urgency_id: 1,
+        description: 'Overnight',
+        priority_order: 1,
+      },
+      requested_ts: '2024-02-21T15:00:00Z',
+    },
   ],
   approver_transcriptions: [
     {

--- a/src/app/portal/services/case/case.service.spec.ts
+++ b/src/app/portal/services/case/case.service.spec.ts
@@ -600,4 +600,37 @@ describe('CaseService', () => {
       });
     });
   });
+
+  describe('#mapTranscriptDataToTranscript', () => {
+    it('should map transcript data to transcript', () => {
+      const data: TranscriptData[] = [
+        {
+          transcription_id: 1,
+          hearing_id: 2,
+          hearing_date: '2023-10-12',
+          type: 'Sentencing remarks',
+          requested_on: '2023-10-12T00:00:00Z',
+          requested_by_name: 'Joe Bloggs',
+          status: 'Complete',
+        },
+      ];
+      expect(service['mapTranscriptDataToTranscript'](data)).toEqual([
+        {
+          id: 1,
+          hearingId: 2,
+          hearingDate: DateTime.fromISO('2023-10-12'),
+          type: 'Sentencing remarks',
+          requestedOn: DateTime.fromISO('2023-10-12T00:00:00Z'),
+          status: 'Complete',
+          requestedByName: 'Joe Bloggs',
+        },
+      ]);
+    });
+
+    it('should map Approved status to With Transcriber', () => {
+      const data = [{ status: 'Approved' }];
+      const mappedData = service['mapTranscriptDataToTranscript'](data as TranscriptData[]);
+      expect(mappedData[0].status).toEqual('With Transcriber');
+    });
+  });
 });

--- a/src/app/portal/services/case/case.service.ts
+++ b/src/app/portal/services/case/case.service.ts
@@ -163,7 +163,7 @@ export class CaseService {
       type: t.type,
       requestedOn: DateTime.fromISO(t.requested_on),
       requestedByName: t.requested_by_name,
-      status: t.status,
+      status: t.status === 'Approved' ? 'With Transcriber' : t.status,
     }));
   }
 

--- a/src/app/portal/services/transcription/transcription.service.spec.ts
+++ b/src/app/portal/services/transcription/transcription.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import {
+  TranscriptRequestData,
   TranscriptionDetails,
   TranscriptionDetailsData,
   TranscriptionRequest,
@@ -514,6 +515,14 @@ describe('TranscriptionService', () => {
       const result = service.getHearingRequestDetailsFromTranscript(mockTranscription);
 
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('#mapYourTranscriptRequestData', () => {
+    it('should map Approved status to With Transcriber', () => {
+      const data = [{ status: 'Approved' }] as TranscriptRequestData[];
+      const mappedData = service['mapYourTranscriptRequestData'](data);
+      expect(mappedData[0].status).toEqual('With Transcriber');
     });
   });
 });

--- a/src/app/portal/services/transcription/transcription.service.ts
+++ b/src/app/portal/services/transcription/transcription.service.ts
@@ -199,7 +199,7 @@ export class TranscriptionService {
       courthouseName: r.courthouse_name,
       hearingDate: DateTime.fromISO(r.hearing_date),
       transcriptionType: r.transcription_type,
-      status: r.status,
+      status: r.status === 'Approved' ? 'With Transcriber' : r.status,
       urgency: r.transcription_urgency
         ? r.transcription_urgency
         : { transcription_urgency_id: 0, description: '', priority_order: 0 },


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-3133

### Change description ###

'Approved' status now shows as 'With Transcriber' on the following screens:

- Your Transcripts
- Case Transcripts Tab
- Hearing Transcripts Tab

Mapped in the service layer