### PR TITLE
DMP-3526: Make functional tests idempotent: hide-or-delete-file-spec.cy.js

### DIFF
--- a/cypress/e2e/functional/admin-portal/hide-or-delete-file-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/hide-or-delete-file-spec.cy.js
@@ -213,4 +213,9 @@ describe('Admin - Hide or delete file', () => {
       cy.get('.govuk-button').contains('Hide or delete').should('exist');
     });
   });
+
+  after(() => {
+    cy.request('api/admin/transcription-documents/reset');
+    cy.request('api/admin/medias/reset');
+  });
 });

--- a/darts-api-stub/admin/medias/medias.js
+++ b/darts-api-stub/admin/medias/medias.js
@@ -142,7 +142,7 @@ const mediaSearchResults = [
   },
 ];
 
-const media = {
+const defaultMedia = {
   id: 0,
   start_at: '2024-06-11T09:55:18.404Z',
   end_at: '2024-06-11T10:55:18.404Z',
@@ -201,6 +201,15 @@ const media = {
   ],
 };
 
+let updatedMedia = [];
+let media = { ...defaultMedia };
+
+router.get('/reset', (req, res) => {
+  media = { ...defaultMedia };
+  updatedMedia = [];
+  res.sendStatus(202);
+});
+
 router.get('/', (req, res) => {
   const transformed_media_id = req.query.transformed_media_id;
   const transcription_document_id = req.query.transcription_document_id;
@@ -248,7 +257,6 @@ router.post('/:id/hide', (req, res) => {
   res.send(response);
 });
 
-const updatedMedia = [];
 router.get('/:id', (req, res) => {
   media.id = parseInt(req.params.id);
 

--- a/darts-api-stub/admin/transcriptions/transcription-documents.js
+++ b/darts-api-stub/admin/transcriptions/transcription-documents.js
@@ -69,7 +69,7 @@ const documents = [
   },
 ];
 
-const transcription = {
+const defaultTranscription = {
   transcription_document_id: 123,
   transcription_id: 456,
   file_type: 'DOC',
@@ -96,6 +96,17 @@ const transcription = {
     comments: 'This is a comment',
   },
 };
+
+let transcription = { ...defaultTranscription };
+
+let updatedDocs = [];
+
+router.get('/reset', (req, res) => {
+  transcription = { ...defaultTranscription };
+  updatedDocs = [];
+  console.log('reset transcription documents');
+  res.sendStatus(202);
+});
 
 router.post('/search', (req, res) => {
   const { case_number } = req.body;
@@ -128,7 +139,6 @@ router.get('/:transcription_document_id', (req, res) => {
   return res.send(transcription);
 });
 
-const updatedDocs = [];
 router.post('/:transcription_document_id/hide', (req, res) => {
   const body = req.body;
   let response;


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3526](https://tools.hmcts.net/jira/browse/DMP-3526)

### Change description ###

Calling reset endpoint to restore stub state after a functional tests have run to not impact any other tests dependent on the same stub data

`after(() => {
    cy.request('api/admin/transcription-documents/reset');
    cy.request('api/admin/medias/reset');
  });`