### PR TITLE
DMP-3563: Transformed media search - Persist form state and search results

### DIFF
--- a/cypress/e2e/functional/admin-portal/transformed-media-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/transformed-media-spec.cy.js
@@ -55,6 +55,39 @@ describe('Admin - Transformed media screen', () => {
 
       cy.a11y();
     });
+
+    it('persists search criteria and results', () => {
+      cy.get('#requestId').type('1');
+
+      cy.get('summary').contains('Advanced search').click();
+
+      cy.get('#caseId').type('1');
+      cy.get('#courthouse').type('Swansea');
+      cy.get('#hearingDate').type('01/01/2021');
+      cy.get('#owner').type('Phil Taylor');
+      cy.get('#requestedBy').type('Martin Adams');
+
+      cy.get('#specific-date-radio').click();
+      cy.get('#specific').type('01/01/2021');
+
+      cy.get('[data-button="button-search"]').click();
+
+      cy.get('caption').contains('Showing 1-3 of 3 results');
+
+      cy.get('app-data-table').get('a').contains('1').click();
+
+      cy.get('.govuk-back-link').click();
+
+      cy.get('#requestId').should('have.value', '1');
+      cy.get('#caseId').should('have.value', '1');
+      cy.get('#courthouse').should('have.value', 'Swansea');
+      cy.get('#hearingDate').should('have.value', '01/01/2021');
+      cy.get('#owner').should('have.value', 'Phil Taylor');
+      cy.get('#requestedBy').should('have.value', 'Martin Adams');
+      cy.get('#specific').should('have.value', '01/01/2021');
+
+      cy.get('app-data-table').contains('filename.mp3');
+    });
   });
 
   describe('view transformed media', () => {

--- a/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.html
+++ b/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.html
@@ -19,7 +19,7 @@
       [class.govuk-input--error]="form.controls.requestId.errors && form.controls.requestId.touched"
     />
   </div>
-  <details class="govuk-details" [open]="isAdvancedSearch">
+  <details class="govuk-details" [open]="isAdvancedSearch()">
     <summary class="govuk-details__summary" (click)="$event.preventDefault(); toggleAdvancedSearch()">
       <span class="govuk-details__summary-text"> Advanced search </span>
     </summary>
@@ -37,7 +37,7 @@
       <div class="govuk-form-group">
         <app-courthouse-field
           [courthouses]="courthouses"
-          [courthouse]="form.controls.courthouse.value!"
+          [courthouse]="formValues()!.courthouse!"
           (courthouseSelect)="form.get('courthouse')?.patchValue($event); form.get('courthouse')?.markAsDirty()"
           [isInvalid]="form.controls.courthouse.invalid && form.controls.courthouse.touched"
           [errors]="getControlErrorMessage(['courthouse'])"
@@ -76,5 +76,6 @@
   </details>
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button">Search</button>
+    <a class="govuk-link" href="javascript:void(0)" (click)="clear.emit()">Clear search</a>
   </div>
 </form>

--- a/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.spec.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.spec.ts
@@ -22,9 +22,9 @@ describe('SearchTransformedMediaFormComponent', () => {
 
   it('should toggle advanced search', () => {
     component.toggleAdvancedSearch();
-    expect(component.isAdvancedSearch).toBe(true);
+    expect(component.isAdvancedSearch()).toBe(true);
     component.toggleAdvancedSearch();
-    expect(component.isAdvancedSearch).toBe(false);
+    expect(component.isAdvancedSearch()).toBe(false);
   });
 
   it('#onSubmit', () => {

--- a/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media-form/search-transformed-media-form.component.ts
@@ -1,5 +1,6 @@
+import { TransformedMediaSearchFormValues } from '@admin-types/transformed-media/transformed-media-search-form.values';
 import { CommonModule, NgIf } from '@angular/common';
-import { Component, DestroyRef, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, Output, effect, inject, model, output } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CourthouseComponent } from '@common/courthouse/courthouse.component';
 import { DatepickerComponent } from '@common/datepicker/datepicker.component';
@@ -7,6 +8,7 @@ import { SpecificOrRangeDatePickerComponent } from '@common/specific-or-range-da
 import { TransformedMediaSearchFormErrorMessages } from '@constants/transformed-media-search-form-error-messages';
 import { CourthouseData, ErrorSummaryEntry } from '@core-types/index';
 import { FormService } from '@services/form/form.service';
+import { defaultFormValues } from '@services/transformed-media/transformed-media.service';
 import { dateRangeValidator } from '@validators/date-range.validator';
 import { futureDateValidator } from '@validators/future-date.validator';
 import { realDateValidator } from '@validators/real-date.validator';
@@ -35,6 +37,7 @@ export class SearchTransformedMediaFormComponent {
   fb = inject(FormBuilder);
   destroyRef = inject(DestroyRef);
   formService = inject(FormService);
+  formValues = model<TransformedMediaSearchFormValues>(defaultFormValues);
 
   @Input() courthouses: CourthouseData[] = [];
 
@@ -56,10 +59,15 @@ export class SearchTransformedMediaFormComponent {
     ),
   });
 
+  constructor() {
+    effect(() => this.form.patchValue(this.formValues()!));
+  }
+
   @Output() search = new EventEmitter<typeof this.form.value>();
   @Output() errors = new EventEmitter<ErrorSummaryEntry[]>();
+  clear = output();
 
-  isAdvancedSearch = false;
+  isAdvancedSearch = model(false);
 
   onSubmit() {
     this.form.markAllAsTouched();
@@ -89,7 +97,7 @@ export class SearchTransformedMediaFormComponent {
   }
 
   toggleAdvancedSearch() {
-    this.isAdvancedSearch = !this.isAdvancedSearch;
+    this.isAdvancedSearch.set(!this.isAdvancedSearch());
   }
 
   setInputValue(value: string, control: string) {

--- a/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.html
+++ b/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.html
@@ -5,13 +5,16 @@
 @if (courthouses$ | async; as courthouses) {
   <app-search-transformed-media-form
     [courthouses]="courthouses"
+    [formValues]="transformedMediaService.searchFormValues()"
+    [(isAdvancedSearch)]="transformedMediaService.isAdvancedSearch"
     (search)="onSearch($event)"
+    (clear)="transformedMediaService.clearSearch()"
     (errors)="errors = $event"
   />
 }
 
-@if (isSearchFormSubmitted() && !isLoading()) {
-  <app-transformed-media-search-results [results]="results()" />
+@if (transformedMediaService.isSearchFormSubmitted() && !isLoading()) {
+  <app-transformed-media-search-results [results]="transformedMediaService.searchResults()" />
 }
 
 @if (isLoading()) {

--- a/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.spec.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.spec.ts
@@ -3,8 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { User } from '@admin-types/index';
 import { TransformedMediaAdmin } from '@admin-types/transformed-media/transformed-media-admin';
 import { TransformedMediaSearchFormValues } from '@admin-types/transformed-media/transformed-media-search-form.values';
+import { signal } from '@angular/core';
 import { CourthouseService } from '@services/courthouses/courthouses.service';
-import { TransformedMediaService } from '@services/transformed-media/transformed-media.service';
+import { TransformedMediaService, defaultFormValues } from '@services/transformed-media/transformed-media.service';
 import { UserAdminService } from '@services/user-admin/user-admin.service';
 import { DateTime } from 'luxon';
 import { of } from 'rxjs';
@@ -55,6 +56,9 @@ describe('SearchTransformedMediaComponent', () => {
   beforeEach(async () => {
     fakeTransformedMediaService = {
       searchTransformedMedia: jest.fn().mockReturnValue(of(mockTransformedMedia)),
+      isSearchFormSubmitted: signal<boolean>(false),
+      searchResults: signal<TransformedMediaAdmin[]>([]),
+      searchFormValues: signal<TransformedMediaSearchFormValues>(defaultFormValues),
     };
 
     fakeUserAdminService = {
@@ -104,7 +108,7 @@ describe('SearchTransformedMediaComponent', () => {
     it('map results with user details', () => {
       component.onSearch({});
 
-      expect(component.results()).toEqual([
+      expect(component.transformedMediaService.searchResults()).toEqual([
         {
           ...mockTransformedMedia[0],
           mediaRequest: {
@@ -118,7 +122,7 @@ describe('SearchTransformedMediaComponent', () => {
 
     it('set isSearchFormSubmitted to true', () => {
       component.onSearch({});
-      expect(component.isSearchFormSubmitted()).toBe(true);
+      expect(component.transformedMediaService.isSearchFormSubmitted()).toBe(true);
     });
 
     it('should navigate to the transcript page if only one result is returned', () => {

--- a/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.ts
@@ -36,10 +36,7 @@ export class SearchTransformedMediaComponent {
 
   errors: ErrorSummaryEntry[] = [];
   courthouses$ = this.courthouseService.getCourthouses();
-
-  isSearchFormSubmitted = signal<boolean>(false);
   isLoading = signal<boolean>(false);
-  results = signal<TransformedMediaAdmin[]>([]);
 
   onSearch(values: TransformedMediaSearchFormValues) {
     this.isLoading.set(true);
@@ -69,8 +66,8 @@ export class SearchTransformedMediaComponent {
       )
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe((results) => {
-        this.results.set(results);
-        this.isSearchFormSubmitted.set(true);
+        this.transformedMediaService.searchResults.set(results);
+        this.transformedMediaService.isSearchFormSubmitted.set(true);
 
         if (results?.length === 1) {
           // navigate to the transcript document details page

--- a/src/app/admin/services/transformed-media/transformed-media.service.spec.ts
+++ b/src/app/admin/services/transformed-media/transformed-media.service.spec.ts
@@ -12,7 +12,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { DateTime } from 'luxon';
 import { of } from 'rxjs';
-import { TransformedMediaService } from './transformed-media.service';
+import { TransformedMediaService, defaultFormValues } from './transformed-media.service';
 
 describe('TransformedMediaService', () => {
   let service: TransformedMediaService;
@@ -161,6 +161,25 @@ describe('TransformedMediaService', () => {
       req.flush(mockResponse);
 
       expect(result).toEqual(expectedMappedType);
+    });
+
+    it('sets formValues with search criteria', () => {
+      const mockCriteria = {
+        caseId: '123',
+        courthouse: 'courthouse',
+        hearingDate: '01/01/2021',
+        owner: 'owner',
+        requestedBy: 'requestedBy',
+        requestedDate: {
+          specific: '02/02/2022',
+        },
+      } as TransformedMediaSearchFormValues;
+
+      service.searchTransformedMedia(mockCriteria).subscribe();
+
+      httpMock.expectOne({ url: '/api/admin/transformed-medias/search', method: 'POST' });
+
+      expect(service.searchFormValues()).toEqual(mockCriteria);
     });
   });
 
@@ -696,6 +715,22 @@ describe('TransformedMediaService', () => {
       service.unhideAudioFile(mockId).subscribe();
       const req = httpMock.expectOne({ url: `api/admin/medias/${mockId}/hide`, method: 'POST' });
       req.flush({});
+    });
+  });
+
+  describe('clearSearch', () => {
+    it('should clear search results and reset search for state', () => {
+      service.searchResults.set([{} as TransformedMediaAdmin]);
+      service.isSearchFormSubmitted.set(true);
+      service.isAdvancedSearch.set(true);
+      service.searchFormValues.set({} as TransformedMediaSearchFormValues);
+
+      service.clearSearch();
+
+      expect(service.searchResults()).toEqual([]);
+      expect(service.isSearchFormSubmitted()).toBe(false);
+      expect(service.isAdvancedSearch()).toBe(false);
+      expect(service.searchFormValues()).toEqual(defaultFormValues);
     });
   });
 });

--- a/src/app/admin/services/transformed-media/transformed-media.service.ts
+++ b/src/app/admin/services/transformed-media/transformed-media.service.ts
@@ -13,9 +13,24 @@ import { TransformedMediaRequest } from '@admin-types/transformed-media/transfor
 import { TransformedMediaRequestData } from '@admin-types/transformed-media/transformed-media-request-data.interface';
 import { TransformedMediaSearchFormValues } from '@admin-types/transformed-media/transformed-media-search-form.values';
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { DateTime } from 'luxon';
 import { Observable, map } from 'rxjs';
+
+export const defaultFormValues: TransformedMediaSearchFormValues = {
+  requestId: '',
+  caseId: '',
+  courthouse: '',
+  hearingDate: '',
+  owner: '',
+  requestedBy: '',
+  requestedDate: {
+    type: '',
+    specific: '',
+    from: '',
+    to: '',
+  },
+};
 
 @Injectable({
   providedIn: 'root',
@@ -23,7 +38,13 @@ import { Observable, map } from 'rxjs';
 export class TransformedMediaService {
   http = inject(HttpClient);
 
+  searchResults = signal<TransformedMediaAdmin[]>([]);
+  searchFormValues = signal<TransformedMediaSearchFormValues>(defaultFormValues);
+  isSearchFormSubmitted = signal<boolean>(false);
+  isAdvancedSearch = signal<boolean>(false);
+
   searchTransformedMedia(searchCriteria: TransformedMediaSearchFormValues): Observable<TransformedMediaAdmin[]> {
+    this.searchFormValues.set(searchCriteria);
     const body = this.mapSearchCriteriaToSearchRequest(searchCriteria);
     return this.http
       .post<TransformedMediaAdminData[]>('/api/admin/transformed-medias/search', body)
@@ -98,6 +119,13 @@ export class TransformedMediaService {
     return this.http
       .post<FileHideData>(`api/admin/medias/${id}/hide`, { is_hidden: false })
       .pipe(map((res) => this.mapHideFileResponse(res)));
+  }
+
+  clearSearch() {
+    this.searchResults.set([]);
+    this.isSearchFormSubmitted.set(false);
+    this.isAdvancedSearch.set(false);
+    this.searchFormValues.set(defaultFormValues);
   }
 
   private mapHidePostRequest(body: FileHideOrDeleteFormValues) {


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3563](https://tools.hmcts.net/jira/browse/DMP-3563)

### Change description ###

- Add clearSearch() to the form / service
- Moved state into a signal based service instead of component props to enable form and results persistence when navigating to and from screen
- Covered with functional test
- Ignore branch name, wrong ticket ref