### PR TITLE
DMP-3590 - Courthouse autocomplete uses display name now

### DIFF
--- a/src/app/core/components/common/courthouse/courthouse.component.ts
+++ b/src/app/core/components/common/courthouse/courthouse.component.ts
@@ -49,7 +49,7 @@ export class CourthouseComponent implements AfterViewInit, OnChanges {
   ngAfterViewInit(): void {
     if (this.courthouses.length) {
       this.props.element = this.autocompleteContainer.nativeElement;
-      this.props.source = this.courthouses.map((courthouse) => courthouse.courthouse_name);
+      this.props.source = this.courthouses.map((courthouse) => courthouse.display_name);
       this.props.defaultValue = this.courthouse;
       accessibleAutocomplete(this.props);
     }


### PR DESCRIPTION

https://tools.hmcts.net/jira/browse/DMP-3590


Checked usage of courthouse and all looks to be referencing display name