### PR TITLE
Fix transcript search bug

### DIFF
--- a/src/app/admin/components/transcripts/transcripts.component.html
+++ b/src/app/admin/components/transcripts/transcripts.component.html
@@ -4,13 +4,12 @@
 @let results = transcriptService.searchResults();
 @let completedResults = transcriptService.completedSearchResults();
 @let loading = isLoading();
-@let tab = transcriptService.tab();
 
 <app-validation-error-summary [errors]="errors" />
 <app-govuk-heading size="xl">Transcripts</app-govuk-heading>
 
 @if (courthouses) {
-  <app-tabs (tabChange)="onTabChanged($event.name)" [default]="tab">
+  <app-tabs (tabChange)="onTabChanged($event.name)" [default]="tab()">
     <div *tab="'Requests'">
       <app-govuk-heading>Transcript requests</app-govuk-heading>
 

--- a/src/app/admin/components/transcripts/transcripts.component.spec.ts
+++ b/src/app/admin/components/transcripts/transcripts.component.spec.ts
@@ -221,7 +221,7 @@ describe('TranscriptsComponent', () => {
     expect(component.router.navigate).toHaveBeenCalledWith(['/admin/transcripts', 1]);
   });
 
-  it('only search request search if the tab is "Requests"', fakeAsync(() => {
+  it('only search for transcript requests if the tab is "Requests"', fakeAsync(() => {
     jest.spyOn(component.transcriptService, 'search');
     component.tab.set('Requests');
     component.isSubmitted$.next(true);

--- a/src/app/admin/components/transcripts/transcripts.component.ts
+++ b/src/app/admin/components/transcripts/transcripts.component.ts
@@ -47,11 +47,12 @@ export class TranscriptsComponent {
   search$ = new Subject<TranscriptionSearchFormValues | null>();
   isLoading = signal(false);
   isSubmitted$ = this.transcriptService.hasSearchFormBeenSubmitted$;
+  tab = this.transcriptService.tab;
 
   results$ = combineLatest([this.search$, this.isSubmitted$, this.courthouses$, this.transcriptionStatuses$]).pipe(
     tap(() => this.startLoading()),
     switchMap(([values, isSubmitted, courthouses, statuses]) => {
-      if (!values || !isSubmitted) {
+      if (!values || !isSubmitted || this.tab() === 'Completed transcripts') {
         return of(null);
       }
       return (
@@ -74,11 +75,12 @@ export class TranscriptsComponent {
   completedResults$ = combineLatest([this.search$, this.isSubmitted$]).pipe(
     tap(() => this.startLoading()),
     switchMap(([values, isSubmitted]) => {
-      if (!values || !isSubmitted) {
+      if (!values || !isSubmitted || this.tab() === 'Requests') {
         return of(null);
       }
       return this.transcriptService.searchCompletedTranscriptions(values);
     }),
+    takeUntilDestroyed(),
     tap(() => this.stopLoading()),
     tap((results) => {
       if (results?.length === 1) {


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Admin Portal > Transcript search has two tabs, one tab to search for "transcript requests" and one tab for "completed transcripts".

There is a bug where both searches were being triggered for both tabs causing a race condition and redirecting the user to the wrong place in the event of a single result. This PR addresses this.