### PR TITLE
DMP-3591 - Add scroll to admin search

### DIFF
--- a/src/app/admin/components/search/search-form/search-form.component.html
+++ b/src/app/admin/components/search/search-form/search-form.component.html
@@ -94,6 +94,6 @@
 
   <div class="govuk-button-group">
     <button id="confirm-button" class="govuk-button" (mousedown)="(false)" type="submit">Search</button>
-    <a class="govuk-link" href="javascript:void(0)" (click)="clear.emit()">Clear search</a>
+    <a class="govuk-link" href="javascript:void(0)" (click)="onClear()">Clear search</a>
   </div>
 </form>

--- a/src/app/admin/components/search/search-form/search-form.component.ts
+++ b/src/app/admin/components/search/search-form/search-form.component.ts
@@ -1,5 +1,4 @@
 import { Courthouse } from '@admin-types/courthouses/courthouse.type';
-import { JsonPipe } from '@angular/common';
 import { Component, computed, effect, inject, input, model, output } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { AutoCompleteComponent, AutoCompleteItem } from '@common/auto-complete/auto-complete.component';
@@ -26,7 +25,7 @@ export type AdminSearchFormValues = {
 @Component({
   selector: 'app-search-form',
   standalone: true,
-  imports: [AutoCompleteComponent, SpecificOrRangeDatePickerComponent, ReactiveFormsModule, JsonPipe],
+  imports: [AutoCompleteComponent, SpecificOrRangeDatePickerComponent, ReactiveFormsModule],
   templateUrl: './search-form.component.html',
   styleUrl: './search-form.component.scss',
 })
@@ -95,5 +94,10 @@ export class SearchFormComponent {
     this.errors.emit([]);
 
     this.search.emit(this.form.value as AdminSearchFormValues);
+  }
+
+  onClear() {
+    this.errors.emit([]);
+    this.clear.emit();
   }
 }

--- a/src/app/admin/components/search/search.component.html
+++ b/src/app/admin/components/search/search.component.html
@@ -7,7 +7,7 @@
   [formValues]="searchService.formValues()"
   (search)="onSearch($event)"
   (clear)="searchService.clearSearch()"
-  (errors)="formValidationErrors.set($event)"
+  (errors)="onValidationErrors($event)"
 />
 
 @if (searchService.hasFormBeenSubmitted()) {

--- a/src/app/admin/components/search/search.component.spec.ts
+++ b/src/app/admin/components/search/search.component.spec.ts
@@ -5,9 +5,18 @@ import { CourthouseData } from '@core-types/courthouse/courthouse.interface';
 import { TabDirective } from '@directives/tab.directive';
 import { AdminSearchService, defaultFormValues } from '@services/admin-search/admin-search.service';
 import { CourthouseService } from '@services/courthouses/courthouses.service';
+import { ScrollService } from '@services/scroll/scroll.service';
 import { of } from 'rxjs';
 import { AdminSearchFormValues } from './search-form/search-form.component';
 import { SearchComponent } from './search.component';
+
+const mockFormValues: AdminSearchFormValues = {
+  caseId: '123',
+  courtroom: '1',
+  courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
+  hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
+  resultsFor: 'Cases',
+};
 
 const fakeCourthouseService = {
   getCourthouses: jest.fn().mockReturnValue(of([{ id: 1, display_name: 'Courthouse 1' }] as CourthouseData[])),
@@ -39,6 +48,7 @@ describe('SearchComponent', () => {
       providers: [
         { provide: CourthouseService, useValue: fakeCourthouseService },
         { provide: AdminSearchService, useValue: fakeAdminSearchService },
+        { provide: ScrollService, useValue: { scrollTo: jest.fn() } },
       ],
     }).compileComponents();
 
@@ -74,13 +84,7 @@ describe('SearchComponent', () => {
       const searchErrorSpy = jest.spyOn(component.searchService.searchError, 'set');
       const formValuesSpy = jest.spyOn(component.searchService.formValues, 'set');
 
-      component.onSearch({
-        caseId: '123',
-        courtroom: '1',
-        courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-        hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
-        resultsFor: 'Cases',
-      });
+      component.onSearch(mockFormValues);
 
       tick();
 
@@ -88,31 +92,13 @@ describe('SearchComponent', () => {
       expect(isLoadingSpy).toHaveBeenCalledTimes(1);
       expect(isSubmitedSpy).toHaveBeenCalledWith(true);
       expect(searchErrorSpy).toHaveBeenCalledWith(null);
-      expect(formValuesSpy).toHaveBeenCalledWith({
-        caseId: '123',
-        courtroom: '1',
-        courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-        hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
-        resultsFor: 'Cases',
-      });
+      expect(formValuesSpy).toHaveBeenCalledWith(mockFormValues);
     }));
 
     describe('case search', () => {
       it('call getCases with correct values', () => {
-        component.onSearch({
-          caseId: '123',
-          courtroom: '1',
-          courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-          hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
-          resultsFor: 'Cases',
-        });
-        expect(fakeAdminSearchService.getCases).toHaveBeenCalledWith({
-          caseId: '123',
-          courtroom: '1',
-          courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-          hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
-          resultsFor: 'Cases',
-        });
+        component.onSearch(mockFormValues);
+        expect(fakeAdminSearchService.getCases).toHaveBeenCalledWith(mockFormValues);
       });
     });
 
@@ -142,6 +128,25 @@ describe('SearchComponent', () => {
         });
       });
     });
+
+    it('scrolls to search results', () => {
+      const scrollToSpy = jest.spyOn(component.scrollService, 'scrollTo');
+      component.onSearch({ ...defaultFormValues } as AdminSearchFormValues);
+      expect(scrollToSpy).toHaveBeenCalledWith(component.resultsSelector);
+    });
+  });
+
+  describe('onValidationErrors', () => {
+    it('set formValidationErrors', () => {
+      component.onValidationErrors([{ fieldId: 'error', message: 'error' }]);
+      expect(component.formValidationErrors()).toEqual([{ fieldId: 'error', message: 'error' }]);
+    });
+
+    it('scrolls to validation errors', () => {
+      const scrollToSpy = jest.spyOn(component.scrollService, 'scrollTo');
+      component.onValidationErrors([{ fieldId: 'error', message: 'error' }]);
+      expect(scrollToSpy).toHaveBeenCalledWith(component.validationSummarySelector);
+    });
   });
 
   describe('tabChange', () => {
@@ -152,21 +157,12 @@ describe('SearchComponent', () => {
 
     it('triggers search with last search form values', () => {
       const onSearchSpy = jest.spyOn(component, 'onSearch');
-      component.searchService.formValues.set({
-        caseId: '123',
-        courtroom: '1',
-        courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-        hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
-        resultsFor: 'Cases',
-      });
+      component.searchService.formValues.set(mockFormValues);
 
       component.tabChange({ name: 'Hearings' } as TabDirective);
 
       expect(onSearchSpy).toHaveBeenCalledWith({
-        caseId: '123',
-        courtroom: '1',
-        courthouses: [{ id: 1, displayName: 'Courthouse 1' } as Courthouse],
-        hearingDate: { type: 'specific', specific: '01/01/2021', from: '', to: '' },
+        ...mockFormValues,
         resultsFor: 'Hearings',
       });
     });

--- a/src/app/admin/services/admin-search/admin-search.service.ts
+++ b/src/app/admin/services/admin-search/admin-search.service.ts
@@ -37,7 +37,7 @@ export class AdminSearchService {
   http = inject(HttpClient);
 
   // signals to store previous search results and search form state
-  formValues = signal<AdminSearchFormValues>(defaultFormValues);
+  formValues = signal<AdminSearchFormValues>({ ...defaultFormValues });
   hasFormBeenSubmitted = signal<boolean>(false);
   cases = signal<AdminCaseSearchResult[]>([]);
   events = signal<AdminEventSearchResult[]>([]);
@@ -93,7 +93,7 @@ export class AdminSearchService {
     this.audio.set([]);
     this.searchError.set(null);
     this.isLoading.set(false);
-    this.formValues.set(defaultFormValues);
+    this.formValues.set({ ...defaultFormValues });
     this.hasFormBeenSubmitted.set(false);
   }
 

--- a/src/app/core/services/form/form.service.ts
+++ b/src/app/core/services/form/form.service.ts
@@ -49,7 +49,7 @@ export class FormService {
     const formControls = form.controls;
 
     return Object.keys(formControls)
-      .filter((controlName) => formControls[controlName].errors)
+      .filter((controlName) => formControls[controlName].invalid)
       .map((controlName) => {
         const control = formControls[controlName];
         if (control instanceof FormGroup) {

--- a/src/app/core/services/scroll/scroll.service.spec.ts
+++ b/src/app/core/services/scroll/scroll.service.spec.ts
@@ -1,0 +1,49 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+
+import { ScrollService } from './scroll.service';
+
+describe('ScrollService', () => {
+  let service: ScrollService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ScrollService);
+  });
+
+  beforeAll(() => {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  // After all tests, clean up the mock
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('scrollTo', () => {
+    it('should scroll to the element with the given selector', fakeAsync(() => {
+      const element = document.createElement('div');
+      element.id = 'test';
+      document.body.appendChild(element);
+
+      const scrollIntoViewSpy = jest.spyOn(element, 'scrollIntoView');
+
+      service.scrollTo('#test');
+      tick(100);
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+    }));
+
+    it('should log an error if the element is not found', fakeAsync(() => {
+      const consoleErrorSpy = jest.spyOn(console, 'error');
+
+      service.scrollTo('#none');
+      tick(100);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Element with selector #none not found');
+    }));
+  });
+});

--- a/src/app/core/services/scroll/scroll.service.ts
+++ b/src/app/core/services/scroll/scroll.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ScrollService {
+  scrollTo(selector: string) {
+    setTimeout(() => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+      } else {
+        console.error(`Element with selector ${selector} not found`);
+      }
+    }, 100);
+  }
+}


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3591](https://tools.hmcts.net/jira/browse/DMP-3591)

### Change description ###

- Add ScrollService `scrollService.scrollTo(cssSelector)`
- Only added to Admin search screen for now to see if this actually works in production before rolling it out across the app
- Fix validation error summary bug not showing for nested form controls
- Fix clear search bug
