### PR TITLE
DMP-3596 - Courthouse caching

### DIFF
--- a/src/app/admin/components/courthouses/create-courthouse/create-courthouse.component.ts
+++ b/src/app/admin/components/courthouses/create-courthouse/create-courthouse.component.ts
@@ -72,6 +72,7 @@ export class CreateCourthouseComponent {
     if (!createCourthouse.regionId) delete createCourthouse.regionId;
     this.courthouseService.createCourthouse(createCourthouse).subscribe((courthouse) => {
       this.router.navigate(['/admin/courthouses', courthouse.id], { queryParams: { newCourthouse: true } });
+      this.courthouseService.clearCourthouseCache();
     });
   }
 

--- a/src/app/admin/services/courthouses/courthouse.service.spec.ts
+++ b/src/app/admin/services/courthouses/courthouse.service.spec.ts
@@ -202,17 +202,32 @@ describe('CourthouseService', () => {
   });
 
   describe('#getCourthouses', () => {
-    it('should return proper courthouse data', () => {
-      const mockCourthouses: CourthouseData[] = [];
+    it('should return cached value without firing request if cache exists', () => {
+      service['cachedCourthouses'] = courthouseData; // Set the cached data
 
+      let courthouseList;
       service.getCourthouses().subscribe((courthouses: CourthouseData[]) => {
-        expect(courthouses).toEqual(mockCourthouses);
+        courthouseList = courthouses;
       });
+      expect(courthouseList).toEqual(courthouseData);
+
+      httpMock.expectNone(GET_COURTHOUSES_PATH);
+    });
+
+    it('should return courthouses and send API request', () => {
+      service.clearCourthouseCache();
+
+      let courthouses: CourthouseData[] = [];
+
+      service.getCourthouses().subscribe((response: CourthouseData[]) => {
+        courthouses = response;
+      });
+
+      expect(courthouses).toEqual([]);
 
       const req = httpMock.expectOne(GET_COURTHOUSES_PATH);
       expect(req.request.method).toBe('GET');
-
-      req.flush(mockCourthouses);
+      req.flush(courthouses);
     });
 
     it('should return empty array on error', () => {

--- a/src/app/admin/services/courthouses/courthouse.service.spec.ts
+++ b/src/app/admin/services/courthouses/courthouse.service.spec.ts
@@ -158,14 +158,17 @@ describe('CourthouseService', () => {
       securityGroupIds: ['1', '2', '3'],
     };
 
-    service.createCourthouse(newCourthouse).subscribe((courthouse: CourthouseData) => {
-      expect(courthouse).toEqual(newCourthouse);
+    let courthouse;
+    service.createCourthouse(newCourthouse).subscribe((courthouseResult: CourthouseData) => {
+      courthouse = courthouseResult;
     });
 
     const req = httpMock.expectOne(`${COURTHOUSES_ADMIN_PATH}`);
     expect(req.request.method).toBe('POST');
 
     req.flush(newCourthouse);
+
+    expect(courthouse).toEqual(newCourthouse);
   });
 
   it('#updateCourthouse', () => {
@@ -176,29 +179,34 @@ describe('CourthouseService', () => {
       securityGroupIds: ['1', '2', '3'],
     };
     const courthouseId = 1;
-
-    service.updateCourthouse(courthouseId, newCourthouse).subscribe((courthouse: CourthouseData) => {
-      expect(courthouse).toEqual(newCourthouse);
+    let courthouse;
+    service.updateCourthouse(courthouseId, newCourthouse).subscribe((courthouseResult: CourthouseData) => {
+      courthouse = courthouseResult;
     });
 
     const req = httpMock.expectOne(`${COURTHOUSES_ADMIN_PATH}/${courthouseId}`);
     expect(req.request.method).toBe('PATCH');
 
     req.flush(newCourthouse);
+
+    expect(courthouse).toEqual(newCourthouse);
   });
 
   it('#getCourthouse', () => {
+    let courthouse;
     const mockCourthouse = {};
     const courthouseId = 1;
 
-    service.getCourthouse(1).subscribe((courthouse: CourthouseData) => {
-      expect(courthouse).toEqual(mockCourthouse);
+    service.getCourthouse(1).subscribe((courthouseResult: CourthouseData) => {
+      courthouse = courthouseResult;
     });
 
     const req = httpMock.expectOne(`${COURTHOUSES_ADMIN_PATH}/${courthouseId}`);
     expect(req.request.method).toBe('GET');
 
     req.flush(mockCourthouse);
+
+    expect(courthouse).toEqual(mockCourthouse);
   });
 
   describe('#getCourthouses', () => {
@@ -247,14 +255,17 @@ describe('CourthouseService', () => {
     it('getCourthouseRegions', () => {
       const mockRegions: Region[] = [];
 
-      service.getCourthouseRegions().subscribe((regions: Region[]) => {
-        expect(regions).toEqual(mockRegions);
+      let regions;
+      service.getCourthouseRegions().subscribe((regionResults: Region[]) => {
+        regions = regionResults;
       });
 
       const req = httpMock.expectOne(GET_COURTHOUSE_REGIONS_PATH);
       expect(req.request.method).toBe('GET');
 
       req.flush(mockRegions);
+
+      expect(regions).toEqual(mockRegions);
     });
 
     it('should return empty array on error', () => {
@@ -285,17 +296,7 @@ describe('CourthouseService', () => {
 
   describe('#getCourthouseTranscriptionCompanies', () => {
     it('should return companies if there is a transcriber role', () => {
-      const mockSecurityRoles: SecurityRoleData[] = [
-        { id: 99, role_name: 'TRANSCRIBER', display_name: 'Transcriber', display_state: true },
-      ];
-
-      service.getCourthouseTranscriptionCompanies().subscribe((securityGroups: SecurityGroup[]) => {
-        expect(securityGroups).toEqual(mockSecurityRoles);
-      });
-
-      httpMock.expectOne(`${GET_SECURITY_ROLES_PATH}`).flush(mockSecurityRoles);
-
-      httpMock.expectOne(`${GET_SECURITY_GROUPS_PATH}?role_ids=99`).flush([
+      const secGroups = [
         {
           id: 1,
           name: 'Company 1',
@@ -306,6 +307,31 @@ describe('CourthouseService', () => {
           name: 'Company 2',
           security_role_id: 2,
         },
+      ];
+      const mockSecurityRoles: SecurityRoleData[] = [
+        { id: 99, role_name: 'TRANSCRIBER', display_name: 'Transcriber', display_state: true },
+      ];
+
+      let securityGroups;
+      service.getCourthouseTranscriptionCompanies().subscribe((securityGroupResults: SecurityGroup[]) => {
+        securityGroups = securityGroupResults;
+      });
+
+      httpMock.expectOne(`${GET_SECURITY_ROLES_PATH}`).flush(mockSecurityRoles);
+
+      httpMock.expectOne(`${GET_SECURITY_GROUPS_PATH}?role_ids=99`).flush(secGroups);
+
+      expect(securityGroups).toEqual([
+        {
+          id: 1,
+          name: 'Company 1',
+          securityRoleId: 1,
+        },
+        {
+          id: 2,
+          name: 'Company 2',
+          securityRoleId: 2,
+        },
       ]);
     });
 
@@ -314,11 +340,14 @@ describe('CourthouseService', () => {
         { id: 1, role_name: 'NOT A TRANSCRIBER', display_name: 'I am not a Transcriber', display_state: true },
       ];
 
-      service.getCourthouseTranscriptionCompanies().subscribe((securityGroups: SecurityGroup[]) => {
-        expect(securityGroups).toEqual(mockSecurityRoles);
+      let companies;
+      service.getCourthouseTranscriptionCompanies().subscribe((results: SecurityGroup[]) => {
+        companies = results;
       });
 
       httpMock.expectOne(`${GET_SECURITY_ROLES_PATH}`).flush(mockSecurityRoles);
+
+      expect(companies).toEqual([]);
 
       httpMock.expectNone(`${GET_SECURITY_GROUPS_PATH}?role_ids=99`);
     });

--- a/src/app/admin/services/courthouses/courthouses.service.ts
+++ b/src/app/admin/services/courthouses/courthouses.service.ts
@@ -12,7 +12,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { CourthouseData } from '@core-types/index';
 import { DateTime } from 'luxon';
-import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of, switchMap, tap } from 'rxjs';
 
 export const GET_COURTHOUSE_REGIONS_PATH = '/api/admin/regions';
 export const GET_COURTHOUSES_PATH = '/api/courthouses';
@@ -24,6 +24,8 @@ export const GET_SECURITY_ROLES_PATH = '/api/admin/security-roles';
   providedIn: 'root',
 })
 export class CourthouseService {
+  private cachedCourthouses: CourthouseData[] | null = null;
+
   constructor(private readonly http: HttpClient) {}
 
   createCourthouse(courthouse: CreateUpdateCourthouseFormValues): Observable<CourthouseData> {
@@ -45,11 +47,22 @@ export class CourthouseService {
   }
 
   getCourthouses(): Observable<CourthouseData[]> {
+    if (this.cachedCourthouses) {
+      return of(this.cachedCourthouses);
+    }
+
     return this.http.get<CourthouseData[]>(GET_COURTHOUSES_PATH).pipe(
+      tap((courthouses) => {
+        this.cachedCourthouses = courthouses;
+      }),
       catchError(() => {
         return of([]);
       })
     );
+  }
+
+  clearCourthouseCache(): void {
+    this.cachedCourthouses = null;
   }
 
   getCourthouseRegions(): Observable<Region[]> {

--- a/src/app/portal/components/search/search.component.spec.ts
+++ b/src/app/portal/components/search/search.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpClientModule, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -8,6 +8,7 @@ import { CourthouseData, ErrorMessage, ErrorSummaryEntry } from '@core-types/ind
 import { AppConfigService } from '@services/app-config/app-config.service';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { CaseService } from '@services/case/case.service';
+import { CourthouseService } from '@services/courthouses/courthouses.service';
 import { ErrorMessageService } from '@services/error/error-message.service';
 import { HeaderService } from '@services/header/header.service';
 import { of, throwError } from 'rxjs';
@@ -24,6 +25,7 @@ describe('SearchComponent', () => {
   let caseService: CaseService;
   let errorMsgService: ErrorMessageService;
   let headerService: HeaderService;
+  let courthouseService: CourthouseService;
   const courts = [
     { courthouse_name: 'Reading', id: 0, created_date_time: 'mock' },
     { courthouse_name: 'Slough', id: 1, created_date_time: 'mock' },
@@ -42,23 +44,19 @@ describe('SearchComponent', () => {
     headerService = new HeaderService();
     errorMsgService = new ErrorMessageService(headerService, mockRouter);
     caseService = new CaseService(httpClientSpy);
+    courthouseService = new CourthouseService(httpClientSpy);
     jest.spyOn(caseService, 'searchCases').mockReturnValue(of([]));
-    jest.spyOn(caseService, 'getCourthouses').mockReturnValue(of(courts));
+    jest.spyOn(courthouseService, 'getCourthouses').mockReturnValue(of(courts));
 
     TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        FormsModule,
-        HttpClientModule,
-        SearchComponent,
-        CaseSearchResultsComponent,
-        CourthouseComponent,
-      ],
+      imports: [ReactiveFormsModule, FormsModule, SearchComponent, CaseSearchResultsComponent, CourthouseComponent],
       providers: [
         { provide: AppInsightsService, useValue: fakeAppInsightsService },
         { provide: AppConfigService, useValue: fakeAppConfigService },
         { provide: CaseService, useValue: caseService },
+        { provide: CourthouseService, useValue: courthouseService },
         { provide: ErrorMessageService, useValue: errorMsgService },
+        provideHttpClient(),
       ],
     });
     fixture = TestBed.createComponent(SearchComponent);

--- a/src/app/portal/components/search/search.component.ts
+++ b/src/app/portal/components/search/search.component.ts
@@ -8,6 +8,7 @@ import { ValidationErrorSummaryComponent } from '@components/common/validation-e
 import { ErrorSummaryEntry, FieldErrors } from '@core-types/index';
 import { SearchFormValues } from '@portal-types/index';
 import { CaseService } from '@services/case/case.service';
+import { CourthouseService } from '@services/courthouses/courthouses.service';
 import { ErrorMessageService } from '@services/error/error-message.service';
 import { futureDateValidator } from '@validators/future-date.validator';
 import { Subscription, catchError, of } from 'rxjs';
@@ -59,7 +60,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   isAdvancedSearch = false;
   datePatternValidator = Validators.pattern(/^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/);
   dateValidators = [this.datePatternValidator, futureDateValidator];
-  courthouses$ = this.caseService.getCourthouses();
+  courthouses$ = this.courthouseService.getCourthouses();
   courthouse = '';
 
   // Retrieve Previous Search Results
@@ -69,6 +70,7 @@ export class SearchComponent implements OnInit, OnDestroy {
 
   constructor(
     private caseService: CaseService,
+    private courthouseService: CourthouseService,
     private errorMsgService: ErrorMessageService
   ) {}
 

--- a/src/app/portal/services/case/case.service.spec.ts
+++ b/src/app/portal/services/case/case.service.spec.ts
@@ -1,7 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { CourthouseData } from '@core-types/index';
 import {
   Annotations,
   AnnotationsData,
@@ -17,7 +16,6 @@ import {
   Transcript,
   TranscriptData,
 } from '@portal-types/index';
-import { GET_COURTHOUSES_PATH } from '@services/courthouses/courthouses.service';
 import { MappingService } from '@services/mapping/mapping.service';
 import { DateTime } from 'luxon';
 import {
@@ -154,45 +152,6 @@ describe('CaseService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-  });
-
-  describe('#getCourthouses', () => {
-    it('should get courthouses', () => {
-      const mockCourthouses: CourthouseData[] = [
-        {
-          id: 1,
-          courthouse_name: 'COURTHOUSENAME',
-          display_name: 'DISPLAYNAME',
-          code: 1,
-          created_date_time: '2024-01-01',
-          last_modified_date_time: 'string',
-          region_id: 1,
-          security_group_ids: [1],
-          has_data: false,
-        },
-      ];
-
-      service.getCourthouses().subscribe((courthouses: CourthouseData[]) => {
-        expect(courthouses).toEqual(mockCourthouses);
-      });
-
-      const req = httpMock.expectOne(GET_COURTHOUSES_PATH);
-      expect(req.request.method).toBe('GET');
-
-      req.flush(mockCourthouses);
-    });
-
-    it('on error', () => {
-      let mockCourthouses!: CourthouseData[];
-
-      service.getCourthouses().subscribe((courthouses) => (mockCourthouses = courthouses));
-
-      const req = httpMock.expectOne(GET_COURTHOUSES_PATH);
-      expect(req.request.method).toBe('GET');
-      req.flush(null, { status: 500, statusText: 'Server Error' });
-
-      expect(mockCourthouses).toEqual([]);
-    });
   });
 
   it('#getCase', () => {

--- a/src/app/portal/services/case/case.service.ts
+++ b/src/app/portal/services/case/case.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { CourthouseData } from '@core-types/index';
 import { CaseEvent } from '@portal-types/events/case-event';
 import { CaseEventData } from '@portal-types/events/case-event-data.interface';
 import {
@@ -21,7 +20,6 @@ import {
 } from '@portal-types/index';
 import { MappingService } from '@services/mapping/mapping.service';
 import { DateTime } from 'luxon';
-import { catchError, of } from 'rxjs';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { shareReplay } from 'rxjs/internal/operators/shareReplay';
@@ -37,14 +35,6 @@ export const GET_CASE_RETENTION_HISTORY = '/api/retentions';
 })
 export class CaseService {
   constructor(private readonly http: HttpClient) {}
-
-  getCourthouses(): Observable<CourthouseData[]> {
-    return this.http.get<CourthouseData[]>(GET_COURTHOUSES_PATH).pipe(
-      catchError(() => {
-        return of([]);
-      })
-    );
-  }
 
   // Store for previous search results and form values
   searchResults$: Observable<CaseSearchResult[] | null> | null = null;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3596

getCourhouses now returns cached result if available. Cache is cleared upon creating new courthouse to enable up to date results. 

Cleaned up older false positive tests in courthouse service spec

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
