### PR TITLE
Remove TBD comments

### DIFF
--- a/src/app/admin/services/transcription-admin/transcription-admin.service.ts
+++ b/src/app/admin/services/transcription-admin/transcription-admin.service.ts
@@ -227,7 +227,6 @@ export class TranscriptionAdminService {
   }
 
   private mapHidePostRequest(body: FileHideOrDeleteFormValues) {
-    //TBD in future, deleting audio files
     return {
       is_hidden: true,
       admin_action: {

--- a/src/app/admin/services/transformed-media/transformed-media.service.ts
+++ b/src/app/admin/services/transformed-media/transformed-media.service.ts
@@ -129,7 +129,6 @@ export class TransformedMediaService {
   }
 
   private mapHidePostRequest(body: FileHideOrDeleteFormValues) {
-    //TBD in future, deleting audio files
     return {
       is_hidden: true,
       admin_action: {


### PR DESCRIPTION
Double checking delete transcript would work. Confirmed it would speaking to Chris B, deletion/hidden is driven by the reason_id passed into the payload. That flag/logic is therefore made in the BE.

No FE changes needed

Removed some TBD comments for hiding/deleting audio/transcript

