### PR TITLE
DMP-3761: Remove update to unassiged transcript count on unassigned request call

### DIFF
--- a/src/app/portal/services/transcription/transcription.service.ts
+++ b/src/app/portal/services/transcription/transcription.service.ts
@@ -36,10 +36,7 @@ export class TranscriptionService {
   private readonly urgencies$ = this.http.get<Urgency[]>('/api/transcriptions/urgencies').pipe(shareReplay(1));
 
   unassignedRequests$ = timer(0, this.DATA_POLL_INTERVAL_SECS * 1000).pipe(
-    switchMap(() => this.getWorkRequests(false)),
-    tap((requests: WorkRequest[]) => {
-      this.countService.setUnassignedTranscriptCount(requests.length);
-    })
+    switchMap(() => this.getWorkRequests(false))
   );
 
   assignedRequests$ = timer(0, this.DATA_POLL_INTERVAL_SECS * 1000).pipe(


### PR DESCRIPTION
### Jira link (if applicable)

[DMP-3761](https://tools.hmcts.net/jira/browse/DMP-3761)

### Change description ###

Remove update to unassiged transcript count on unassigned request call as the response contains max of 500 therefore throwing off the count every time the Transcript request page was visited.