### PR TITLE
DMP-3745: Fix error messages on add annotation

### DIFF
--- a/darts-api-stub/annotations/annotations.js
+++ b/darts-api-stub/annotations/annotations.js
@@ -22,7 +22,7 @@ const getAnnotationDocumentByAnnotationAndDocumentId = (annotationId, annotation
 };
 
 router.post('', (req, res) => {
-  res.status(201).send({
+  res.status(200).send({
     annotation_id: 1,
   });
 });

--- a/src/app/core/validators/max-file-size.validator.ts
+++ b/src/app/core/validators/max-file-size.validator.ts
@@ -3,7 +3,7 @@ import { AbstractControl, ValidatorFn } from '@angular/forms';
 export function maxFileSizeValidator(maxSizeInMB: number, message?: string): ValidatorFn {
   return (control: AbstractControl): { [key: string]: unknown } | null => {
     const fileSizeInBytes = (control.value as File)?.size;
-    const maxSizeInBytes = maxSizeInMB * 1024 * 1024;
+    const maxSizeInBytes = maxSizeInMB * 1000 * 1000;
 
     if (fileSizeInBytes && fileSizeInBytes > maxSizeInBytes) {
       return {

--- a/src/app/portal/components/hearing/add-annotation/add-annotation.component.html
+++ b/src/app/portal/components/hearing/add-annotation/add-annotation.component.html
@@ -17,6 +17,7 @@
     hint="This must be in a doc or docx format. Maximum file size 20MB."
     [isInvalid]="this.fileControl.invalid && this.fileControl.touched"
     [errorMessage]="errors().length ? errors()[0].message : ''"
+    allowedFileTypes=".doc,.docx"
   />
 
   <label for="annotation-comments">

--- a/src/app/portal/components/hearing/add-annotation/add-annotation.component.spec.ts
+++ b/src/app/portal/components/hearing/add-annotation/add-annotation.component.spec.ts
@@ -143,7 +143,7 @@ describe('AddAnnotationComponent', () => {
     describe('Error messages', () => {
       it('set error message when fileControl is required', () => {
         component.fileControl.setValue(null);
-        expect(component.errors()[0].message).toBe('You must upload a file to complete this request');
+        expect(component.errors()[0].message).toBe('You need to upload a file');
       });
 
       it('set error message when filesize is too large', () => {

--- a/src/app/portal/components/hearing/add-annotation/add-annotation.component.ts
+++ b/src/app/portal/components/hearing/add-annotation/add-annotation.component.ts
@@ -68,9 +68,7 @@ export class AddAnnotationComponent implements OnInit, OnDestroy {
     }
 
     if (this.fileControl.errors?.required) {
-      this.errors.set([
-        { fieldId: 'file-upload-annotation', message: 'You must upload a file to complete this request' },
-      ]);
+      this.errors.set([{ fieldId: 'file-upload-annotation', message: 'You need to upload a file' }]);
     }
 
     if (this.fileControl.errors?.maxFileSize) {

--- a/src/app/portal/components/hearing/add-annotation/add-annotation.component.ts
+++ b/src/app/portal/components/hearing/add-annotation/add-annotation.component.ts
@@ -79,6 +79,8 @@ export class AddAnnotationComponent implements OnInit, OnDestroy {
   });
 
   onComplete() {
+    this.fileControl.markAsTouched();
+
     if (this.fileControl.invalid) return;
 
     const comments = this.annotationComments.value;


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DMP-3745

### Change description

- Mark control as touched on submit so that validation fires on submitting empty form.
- Disallow .zip file upload as backend returns error.
- Adjust allowed file size to 1000 x 1000 instead of 1024 x 1024.

