### PR TITLE
DMP-2596: Fix courthouse cache and routerLink

### DIFF
--- a/src/app/admin/components/courthouses/courthouse-search-results/courthouse-search-results.component.html
+++ b/src/app/admin/components/courthouses/courthouse-search-results/courthouse-search-results.component.html
@@ -11,7 +11,7 @@
       <app-data-table [rows]="results" [columns]="columns" [caption]="caption" [sortAndPaginateOnRowsChanged]="false">
         <ng-template [tableRowTemplate]="results" let-row>
           <td>
-            <a class="govuk-link" [href]="'/admin/courthouses/' + row.id">{{ row.courthouseName }}</a>
+            <a class="govuk-link" [routerLink]="[row.id]">{{ row.courthouseName }}</a>
           </td>
           <td>{{ row.displayName }}</td>
           <td>{{ row.region?.name }}</td>

--- a/src/app/admin/components/courthouses/create-courthouse/create-courthouse.component.ts
+++ b/src/app/admin/components/courthouses/create-courthouse/create-courthouse.component.ts
@@ -72,7 +72,6 @@ export class CreateCourthouseComponent {
     if (!createCourthouse.regionId) delete createCourthouse.regionId;
     this.courthouseService.createCourthouse(createCourthouse).subscribe((courthouse) => {
       this.router.navigate(['/admin/courthouses', courthouse.id], { queryParams: { newCourthouse: true } });
-      this.courthouseService.clearCourthouseCache();
     });
   }
 

--- a/src/app/admin/services/courthouses/courthouses.service.ts
+++ b/src/app/admin/services/courthouses/courthouses.service.ts
@@ -29,7 +29,9 @@ export class CourthouseService {
   constructor(private readonly http: HttpClient) {}
 
   createCourthouse(courthouse: CreateUpdateCourthouseFormValues): Observable<CourthouseData> {
-    return this.http.post<CourthouseData>(`${COURTHOUSES_ADMIN_PATH}`, this.mapToCreateCourthouseRequest(courthouse));
+    return this.http
+      .post<CourthouseData>(`${COURTHOUSES_ADMIN_PATH}`, this.mapToCreateCourthouseRequest(courthouse))
+      .pipe(tap(() => this.clearCourthouseCache()));
   }
 
   updateCourthouse(courthouseId: number, courthouse: CreateUpdateCourthouseFormValues): Observable<CourthouseData> {
@@ -39,7 +41,9 @@ export class CourthouseService {
       region_id: courthouse?.regionId,
       security_group_ids: courthouse?.securityGroupIds,
     };
-    return this.http.patch<CourthouseData>(`${COURTHOUSES_ADMIN_PATH}/${courthouseId}`, updatedCourthouse);
+    return this.http
+      .patch<CourthouseData>(`${COURTHOUSES_ADMIN_PATH}/${courthouseId}`, updatedCourthouse)
+      .pipe(tap(() => this.clearCourthouseCache()));
   }
 
   getCourthouse(courthouseId: number): Observable<CourthouseData> {


### PR DESCRIPTION
### Jira link

[DMP-3596](https://tools.hmcts.net/jira/browse/DMP-3596)

### Change description

- Move `clearCourthouseCache()` into the service as a side effect of creating or updating a courthouse.
- Use `routerLink` directive instead of href attribute. This was causing a hard refresh when clicking on a courthouse search result and therefore losing the cached state.
