### PR TITLE
DMP-3823: Fix missing Case ID field on transcript form bug

### DIFF
--- a/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.html
+++ b/src/app/admin/components/transcripts/search-transcripts-form/search-transcripts-form.component.html
@@ -22,7 +22,7 @@
       <span class="govuk-details__summary-text"> Advanced search </span>
     </summary>
     <div class="govuk-details__text">
-      @if (!isCompletedTranscriptSearch) {
+      @if (!isCompletedTranscriptSearch()) {
         <div class="govuk-form-group">
           <label class="govuk-label" for="caseId"> Case ID </label>
           <input


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DMP-3823

### Change description

Call signal getter `()` as `isCompletedTranscriptSearch` is always truthy as it's a signal
