### PR TITLE
DMP-3845 Audio time request validation change

### DIFF
--- a/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.spec.ts
+++ b/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.spec.ts
@@ -227,17 +227,20 @@ describe('RequestPlaybackAudioComponent', () => {
     });
 
     it('should set errors and emit validation errors when start time is outside the available audio times', () => {
-      const errorSummaryEntry = { fieldId: 'start-time-hour-input', message: fieldErrors.startTime.unavailable };
+      const errorSummaryEntry = [
+        { fieldId: 'start-time-hour-input', message: fieldErrors.startTime.unavailable },
+        { fieldId: 'end-time-hour-input', message: fieldErrors.endTime.unavailable },
+      ];
       const validationErrorSpy = jest.spyOn(component.validationErrorEvent, 'emit');
 
       const audioRequestForm = {
         startTime: {
-          hours: '01',
+          hours: '00',
           minutes: '59',
           seconds: '30',
         },
         endTime: {
-          hours: '15',
+          hours: '01',
           minutes: '20',
           seconds: '22',
         },
@@ -248,22 +251,25 @@ describe('RequestPlaybackAudioComponent', () => {
 
       expect(component.audioRequestForm.controls.startTime.errors).toEqual({ unavailable: true });
       expect(component.audioRequestForm.errors).toEqual({ invalid: true });
-      expect(validationErrorSpy).toHaveBeenCalledWith([errorSummaryEntry, ...component.errorSummary]);
+      expect(validationErrorSpy).toHaveBeenCalledWith(errorSummaryEntry);
     });
 
     it('should set errors and emit validation errors when end time is outside the available audio times', () => {
-      const errorSummaryEntry = { fieldId: 'end-time-hour-input', message: fieldErrors.endTime.unavailable };
+      const errorSummaryEntry = [
+        { fieldId: 'start-time-hour-input', message: fieldErrors.startTime.unavailable },
+        { fieldId: 'end-time-hour-input', message: fieldErrors.endTime.unavailable },
+      ];
       const validationErrorSpy = jest.spyOn(component.validationErrorEvent, 'emit');
 
       const audioRequestForm = {
         startTime: {
-          hours: '02',
-          minutes: '59',
+          hours: '17',
+          minutes: '10',
           seconds: '30',
         },
         endTime: {
           hours: '17',
-          minutes: '20',
+          minutes: '55',
           seconds: '22',
         },
         requestType: 'PLAYBACK',
@@ -273,7 +279,7 @@ describe('RequestPlaybackAudioComponent', () => {
 
       expect(component.audioRequestForm.controls.endTime.errors).toEqual({ unavailable: true });
       expect(component.audioRequestForm.errors).toEqual({ invalid: true });
-      expect(validationErrorSpy).toHaveBeenCalledWith([errorSummaryEntry, ...component.errorSummary]);
+      expect(validationErrorSpy).toHaveBeenCalledWith(errorSummaryEntry);
     });
   });
 });

--- a/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.ts
+++ b/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.ts
@@ -252,7 +252,9 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
     const endDateTime = DateTime.fromISO(`${hearingDate}T${endTimeHours}:${endTimeMinutes}:${endTimeSeconds}`);
 
     //If times are outside
-    this.audios.length > 0 && this.outsideAudioTimesValidation(startDateTime, endDateTime);
+    this.audios.length > 0 &&
+      !this.audioRequestForm.errors?.endTimeBeforeStartTime &&
+      this.outsideAudioTimesValidation(startDateTime, endDateTime);
 
     //Refuse to submit if form is invalid
     if (

--- a/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.ts
+++ b/src/app/portal/components/hearing/request-playback-audio/request-playback-audio.component.ts
@@ -98,12 +98,6 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
 
   public onValidationError() {
     this.errorSummary = [];
-    const formControls = this.f;
-    const idHashMap = new Map<string, string>();
-
-    idHashMap.set('startTime', 'start-time-hour-input');
-    idHashMap.set('endTime', 'end-time-hour-input');
-    idHashMap.set('requestType', 'playback-radio');
 
     //No audio available validation
     if (this.audios.length === 0) {
@@ -123,13 +117,7 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
       return;
     }
 
-    //Gets Validation field errors generically for all fields
-    this.errorSummary = Object.keys(formControls)
-      .filter((fieldId) => formControls[fieldId].errors)
-      .map((fieldId) =>
-        this.getFieldErrorMessages(fieldId).map((message) => ({ fieldId: idHashMap.get(fieldId) ?? '', message }))
-      )
-      .flat();
+    this.errorSummary = this.getErrorSummary();
 
     if (this.audioRequestForm.invalid) {
       if (!this.audioRequestForm.controls.endTime.invalid && this.audioRequestForm.errors?.endTimeBeforeStartTime) {
@@ -141,7 +129,7 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
       }
     }
 
-    this.validationErrorEvent.emit(this.errorSummary);
+    this.errorSummary.length > 0 && this.validationErrorEvent.emit(this.errorSummary);
   }
 
   public setTimes(): void {
@@ -168,39 +156,69 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
     }
   }
 
+  //Gets Validation field errors generically for all fields
+  private getErrorSummary() {
+    const formControls = this.f;
+    const idHashMap = new Map<string, string>();
+
+    idHashMap.set('startTime', 'start-time-hour-input');
+    idHashMap.set('endTime', 'end-time-hour-input');
+    idHashMap.set('requestType', 'playback-radio');
+
+    return Object.keys(formControls)
+      .filter((fieldId) => formControls[fieldId].errors)
+      .map((fieldId) =>
+        this.getFieldErrorMessages(fieldId).map((message) => ({ fieldId: idHashMap.get(fieldId) ?? '', message }))
+      )
+      .flat();
+  }
+
+  //Checks if audio exists within the range of the times
   private outsideAudioTimesValidation(startTime: DateTime, endTime: DateTime): void {
     const errorMessages: ErrorSummaryEntry[] = [];
-
-    const sortedAudioDates = this.audios
-      .map((audio) => [DateTime.fromISO(audio.media_start_timestamp), DateTime.fromISO(audio.media_end_timestamp)])
-      .flat()
-      .sort((a, b) => a.toMillis() - b.toMillis());
-
-    const earliestDate = sortedAudioDates[0];
-    const latestDate = sortedAudioDates[sortedAudioDates.length - 1];
+    let isAudioWithinRange = false;
 
     //Comparing only times not dates
     const startTimeOnly = startTime.set({ year: 0, month: 1, day: 1, millisecond: 0 });
     const endTimeOnly = endTime.set({ year: 0, month: 1, day: 1, millisecond: 0 });
-    const earliestTime = earliestDate.set({ year: 0, month: 1, day: 1, millisecond: 0 });
-    const latestTime = latestDate.set({ year: 0, month: 1, day: 1, millisecond: 0 });
 
-    if (startTimeOnly < earliestTime || startTimeOnly > latestTime) {
+    //Check there is at least one audio within start/end range
+    isAudioWithinRange = this.audios.some((audio) => {
+      const audioStartTime = DateTime.fromISO(audio.media_start_timestamp).set({
+        year: 0,
+        month: 1,
+        day: 1,
+        millisecond: 0,
+      });
+      const audioEndTime = DateTime.fromISO(audio.media_end_timestamp).set({
+        year: 0,
+        month: 1,
+        day: 1,
+        millisecond: 0,
+      });
+      return (
+        (startTimeOnly <= audioStartTime && endTimeOnly >= audioStartTime) ||
+        (startTimeOnly <= audioEndTime && endTimeOnly >= audioEndTime)
+      );
+    });
+
+    if (!isAudioWithinRange) {
       this.audioRequestForm.controls.startTime.setErrors({ unavailable: true });
+      this.audioRequestForm.controls.endTime.setErrors({ unavailable: true });
       this.audioRequestForm.setErrors({ invalid: true });
       errorMessages.push({
         fieldId: 'start-time-hour-input',
         message: fieldErrors.startTime.unavailable,
       });
-    }
-
-    if (endTimeOnly < earliestTime || endTimeOnly > latestTime) {
-      this.audioRequestForm.controls.endTime.setErrors({ unavailable: true });
-      this.audioRequestForm.setErrors({ invalid: true });
       errorMessages.push({
         fieldId: 'end-time-hour-input',
         message: fieldErrors.endTime.unavailable,
       });
+    } else {
+      //Reset in case of previous stored errors
+      this.audioRequestForm.controls.startTime.setErrors(null);
+      this.audioRequestForm.controls.endTime.setErrors(null);
+      this.validationErrorEvent.emit(this.getErrorSummary());
     }
 
     if (errorMessages.length > 0) {
@@ -209,6 +227,12 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
       ];
       this.validationErrorEvent.emit(uniqueErrorMessages);
     }
+  }
+
+  private clearErrors(): void {
+    this.audioRequestForm.controls.startTime.setErrors(null);
+    this.audioRequestForm.controls.endTime.setErrors(null);
+    this.validationErrorEvent.emit([]);
   }
 
   onSubmit() {
@@ -239,6 +263,8 @@ export class RequestPlaybackAudioComponent implements OnChanges, OnInit {
       this.audioRequestForm.invalid
     )
       return;
+
+    this.clearErrors();
 
     this.requestObj = {
       hearing_id: this.hearing.id,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3845

Audio request time validation has been changed now so that, if at least one audio exists within the time range, it is valid.

This means if there is audio for 09:30-11:00 and the user enters 07:00 - 09:45, then this is a valid request.

06:00 - 06:30 would be invalid, as would 10:00 - 10:30.

But 09:44 - 15:00 would be valid.


- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
