### PR TITLE
DMP-3789: Fix view audio hard refresh / deep link bug

### DIFF
--- a/src/app/portal/components/audios/audio-view/audio-view.component.ts
+++ b/src/app/portal/components/audios/audio-view/audio-view.component.ts
@@ -92,7 +92,7 @@ export class AudioViewComponent implements OnDestroy {
   constructor(private errorMsgService: ErrorMessageService) {
     this.transformedMedia = this.router.getCurrentNavigation()?.extras?.state?.transformedMedia;
 
-    if (!this.transformedMedia) {
+    if (this.isInvalidTransformedMedia(this.transformedMedia)) {
       this.router.navigate(['/audios']);
     } else {
       this.requestId = this.transformedMedia.mediaRequestId;
@@ -186,5 +186,14 @@ export class AudioViewComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.errorMsgService.clearErrorMessage();
+  }
+
+  isInvalidTransformedMedia(transformedMedia: TransformedMedia) {
+    return (
+      !transformedMedia ||
+      !transformedMedia.startTime.toISO ||
+      !transformedMedia.endTime.toISO ||
+      !transformedMedia.hearingDate.toISO
+    );
   }
 }


### PR DESCRIPTION
### Jira link

[DMP-3789](https://tools.hmcts.net/jira/browse/DMP-3789)

## Description

`getCurrentNavigation()` works when navigated via the angular router. Hard refresh or deeplinking removes toISO and other Luxon DateTime prototype functions due to the way the state is serliased / deserialised.

The changes ensure that navigation must come from the Your Audio screen.