### PR TITLE
DMP-3927: Fix view transcript back link

### DIFF
--- a/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
@@ -133,6 +133,11 @@ describe('Admin - Transcript requests', () => {
       cy.a11y();
     });
 
+    it('back link', () => {
+      cy.get('a').contains('Back').click();
+      cy.url().should('include', '/admin/transcripts');
+    });
+
     it('transcript links to associated group', () => {
       cy.get('#status-details').contains('Associated groups').get('a').contains('Judiciary').click();
       cy.url().should('include', '/admin/groups/1');

--- a/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.html
+++ b/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.html
@@ -22,7 +22,7 @@
 
   <div class="govuk-button-group">
     <button class="govuk-button" type="submit">Save changes</button>
-    <a class="govuk-link" href="javascript:void(0)" (click)="router.navigate(['/admin/transcripts', transcriptId])"
+    <a class="govuk-link" [routerLink]="['/admin/transcripts', transcriptId]" [queryParams]="{ updatedStatus: false }"
       >Cancel</a
     >
   </div>

--- a/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.ts
+++ b/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe, JsonPipe } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { GovukTextareaComponent } from '@common/govuk-textarea/govuk-textarea.component';
 import { TranscriptStatus } from '@portal-types/index';
@@ -11,7 +11,7 @@ import { TranscriptionAdminService } from '@services/transcription-admin/transcr
 @Component({
   selector: 'app-change-transcript-status',
   standalone: true,
-  imports: [ReactiveFormsModule, GovukHeadingComponent, GovukTextareaComponent, AsyncPipe, JsonPipe],
+  imports: [ReactiveFormsModule, GovukHeadingComponent, GovukTextareaComponent, AsyncPipe, JsonPipe, RouterLink],
   templateUrl: './change-transcript-status.component.html',
   styleUrl: './change-transcript-status.component.scss',
 })

--- a/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
+++ b/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
@@ -2,9 +2,7 @@
 <app-data-table [rows]="rows" [columns]="columns" caption="Transcript search results" [hiddenCaption]="true">
   <ng-template [tableRowTemplate]="rows" let-row>
     <td>
-      <a href="#" class="govuk-link" [routerLink]="[row.id]" [queryParams]="{ backUrl: '/admin/transcripts' }">
-        {{ row.id }}</a
-      >
+      <a class="govuk-link" [routerLink]="[row.id]" [queryParams]="{ backUrl: '/admin/transcripts' }"> {{ row.id }}</a>
     </td>
     <td>{{ row.caseNumber }}</td>
     <td>{{ row.courthouse }}</td>

--- a/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
+++ b/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
@@ -2,7 +2,9 @@
 <app-data-table [rows]="rows" [columns]="columns" caption="Transcript search results" [hiddenCaption]="true">
   <ng-template [tableRowTemplate]="rows" let-row>
     <td>
-      <a href="#" class="govuk-link" [routerLink]="[row.id]"> {{ row.id }}</a>
+      <a href="#" class="govuk-link" [routerLink]="[row.id]" [queryParams]="{ backUrl: '/admin/transcripts' }">
+        {{ row.id }}</a
+      >
     </td>
     <td>{{ row.caseNumber }}</td>
     <td>{{ row.courthouse }}</td>

--- a/src/app/admin/components/transcripts/view-transcript/view-transcript.component.html
+++ b/src/app/admin/components/transcripts/view-transcript/view-transcript.component.html
@@ -1,6 +1,6 @@
-<a href="javascript:void(0)" (click)="location.back()" class="govuk-back-link">Back</a>
+<a [routerLink]="backUrl" class="govuk-back-link">Back</a>
 
-@if (updatedStatus) {
+@if (updatedStatus()) {
   <app-govuk-banner>Status updated</app-govuk-banner>
 }
 

--- a/src/app/admin/components/transcripts/view-transcript/view-transcript.component.ts
+++ b/src/app/admin/components/transcripts/view-transcript/view-transcript.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, Location } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { GovukBannerComponent } from '@common/govuk-banner/govuk-banner.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '@common/loading/loading.component';
@@ -12,6 +12,8 @@ import { TabsComponent } from '@components/common/tabs/tabs.component';
 import { BreadcrumbDirective } from '@directives/breadcrumb.directive';
 import { TabDirective } from '@directives/tab.directive';
 import { TranscriptFacadeService } from '@facades/transcript/transcript-facade.service';
+import { HistoryService } from '@services/history/history.service';
+import { optionalStringToBooleanOrNull } from '@utils/transform.utils';
 import { TranscriptDetailsComponent } from './transcript-details/transcript-details.component';
 
 @Component({
@@ -38,9 +40,13 @@ export class ViewTranscriptComponent {
   transcriptFacade = inject(TranscriptFacadeService);
   route = inject(ActivatedRoute);
   location = inject(Location);
+  historyService = inject(HistoryService);
+  url = inject(Router).url;
+
+  backUrl = this.historyService.getBackUrl(this.url) ?? '/admin/transcripts';
 
   transcriptionId = Number(this.route.snapshot.params.transcriptionId);
-  updatedStatus = Boolean(this.route.snapshot.queryParams.updatedStatus);
+  updatedStatus = input(null, { transform: optionalStringToBooleanOrNull });
 
   transcript = toSignal(this.transcriptFacade.getTranscript(this.transcriptionId));
   history = toSignal(this.transcriptFacade.getHistory(this.transcriptionId), { initialValue: [] });

--- a/src/app/admin/components/users/user-transcripts/user-transcripts.component.html
+++ b/src/app/admin/components/users/user-transcripts/user-transcripts.component.html
@@ -36,7 +36,9 @@
     [isHorizontalScroll]="true"
     ><ng-template [tableRowTemplate]="userTranscripts" let-row>
       <td>
-        <a class="govuk-link" [routerLink]="['/admin/transcripts/', row.id]"> {{ row.id }}</a>
+        <a class="govuk-link" [routerLink]="['/admin/transcripts/', row.id]" [queryParams]="{ backUrl: url }">
+          {{ row.id }}
+        </a>
       </td>
       <td>{{ row.caseNumber }}</td>
       <td>{{ row.courthouse }}</td>

--- a/src/app/admin/components/users/user-transcripts/user-transcripts.component.ts
+++ b/src/app/admin/components/users/user-transcripts/user-transcripts.component.ts
@@ -2,7 +2,7 @@ import { Transcription, TranscriptionStatus } from '@admin-types/transcription';
 import { CommonModule, NgClass } from '@angular/common';
 import { Component, EventEmitter, OnInit, Output, inject } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { GovukTagComponent } from '@common/govuk-tag/govuk-tag.component';
@@ -40,6 +40,7 @@ export class UserTranscriptsComponent implements OnInit {
   route = inject(ActivatedRoute);
   courthouseService = inject(CourthouseService);
   fb = inject(FormBuilder);
+  url = inject(Router).url;
 
   form!: FormGroup;
 

--- a/src/app/core/components/app/app.component.ts
+++ b/src/app/core/components/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { NavigationEnd, Router, RouterLink } from '@angular/router';
+import { NavigationEnd, NavigationStart, Router, RouterLink } from '@angular/router';
 import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { CookiesService } from '@services/cookies/cookies.service';
 import { DynatraceService } from '@services/dynatrace/dynatrace.service';
 import { ErrorMessageService } from '@services/error/error-message.service';
 import { HeaderService } from '@services/header/header.service';
+import { HistoryService } from '@services/history/history.service';
 import { UserService } from '@services/user/user.service';
 import { filter } from 'rxjs';
 import { CookieBannerComponent } from '../cookies/cookie-banner/cookie-banner.component';
@@ -27,17 +28,35 @@ export class AppComponent implements OnInit {
   private userService = inject(UserService);
   private cookiesService = inject(CookiesService);
   private errorMessageService = inject(ErrorMessageService);
+  private historyService = inject(HistoryService);
+
+  private $urlChangesWithBackUrlParams = this.router.events.pipe(
+    filter((event) => event instanceof NavigationStart),
+    filter((event) => event.url.includes('backUrl'))
+  );
+
+  private $navigationEndEvents = this.router.events.pipe(filter((event) => event instanceof NavigationEnd));
 
   public showCookieBanner: boolean = false;
 
   title = 'DARTS portal';
   currentUrl = '';
+
   ngOnInit() {
-    // If url changes show navigation in case it is hidden
-    // This is useful if a user improperly navigates away from a confirmation screen
-    // via the browser back button, for example.
-    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe((e) => {
-      this.currentUrl = (e as NavigationEnd).url.split('#')[0];
+    this.$urlChangesWithBackUrlParams.subscribe(({ url }) => {
+      // When url changes and has backUrl param, add it to history
+      const path = url.split('?')[0];
+      const queryParams = new URLSearchParams(url.split('?')[1]);
+      const backUrl = queryParams.get('backUrl')!;
+      this.historyService.addBackUrl(path, backUrl);
+    });
+
+    this.$navigationEndEvents.subscribe(({ url }) => {
+      this.currentUrl = url.split('#')[0];
+
+      // If url changes show navigation in case it is hidden
+      // This is useful if a user improperly navigates away from a confirmation screen
+      // via the browser back button, for example.
       this.headerService.showNavigation();
       // log the page view with app insights
       this.appInsightsService.logPageView(this.currentUrl, this.currentUrl);

--- a/src/app/core/services/history/history.service.spec.ts
+++ b/src/app/core/services/history/history.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { HistoryService } from './history.service';
+
+describe('HistoryService', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [HistoryService],
+    });
+    service = TestBed.inject(HistoryService);
+  });
+
+  describe('#addBackUrl', () => {
+    it('add a back URL to the history', () => {
+      service.addBackUrl('/current-page', '/back-page');
+      expect(service['backUrlHistory']()).toEqual([['/current-page', '/back-page']]);
+    });
+
+    it('append multiple back URLs', () => {
+      service.addBackUrl('/page-1', '/back-1');
+      service.addBackUrl('/page-2', '/back-2');
+      expect(service['backUrlHistory']()).toEqual([
+        ['/page-1', '/back-1'],
+        ['/page-2', '/back-2'],
+      ]);
+    });
+  });
+
+  describe('#getBackUrl', () => {
+    it('return the most recent back URL for a given URL', () => {
+      service.addBackUrl('/page-1', '/back-1');
+      service.addBackUrl('/page-2', '/back-2');
+      service.addBackUrl('/page-2', '/back-3');
+      const backUrl = service.getBackUrl('/page-2');
+      expect(backUrl).toBe('/back-3');
+    });
+
+    it('returns url even if it is a substring', () => {
+      service.addBackUrl('/page', '/back-1');
+      const backUrl = service.getBackUrl('/page-1?param=value#hash');
+      expect(backUrl).toBe('/back-1');
+    });
+
+    it('return null if no matching URL is found', () => {
+      service.addBackUrl('/page-1', '/back-1');
+      const backUrl = service.getBackUrl('/non-existent-page');
+      expect(backUrl).toBeNull();
+    });
+  });
+
+  describe('#clearHistory', () => {
+    it('clear the back URL history', () => {
+      service.addBackUrl('/page-1', '/back-1');
+      service.clearHistory();
+      expect(service['backUrlHistory']()).toEqual([]);
+    });
+  });
+});

--- a/src/app/core/services/history/history.service.ts
+++ b/src/app/core/services/history/history.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HistoryService {
+  /* 
+    Store the history of back URLs
+    Each entry is a tuple of [currentUrl, backUrl]
+  */
+  private backUrlHistory = signal<[string, string][]>([]);
+
+  addBackUrl(url: string, backUrl: string) {
+    this.backUrlHistory.update((current) => [...current, [url, backUrl]]);
+  }
+
+  getBackUrl(url: string) {
+    const lastBackUrl = this.backUrlHistory()
+      .toReversed()
+      .find(([currentUrl]) => url.includes(currentUrl));
+    return lastBackUrl ? lastBackUrl[1] : null;
+  }
+
+  clearHistory() {
+    this.backUrlHistory.set([]);
+  }
+}

--- a/src/app/core/utils/index.ts
+++ b/src/app/core/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './date.utils';
+export * from './transform.utils';

--- a/src/app/core/utils/transform.utils.ts
+++ b/src/app/core/utils/transform.utils.ts
@@ -1,0 +1,5 @@
+// Convert 'true' or 'false' string to boolean
+export const optionalStringToBooleanOrNull = (string?: string): boolean | null => {
+  if (string === undefined) return null;
+  else return string === 'true';
+};


### PR DESCRIPTION
### Jira link

[DMP-3927](https://tools.hmcts.net/jira/browse/DMP-3927)
[DMP-3721](https://tools.hmcts.net/jira/browse/DMP-3721)

### Change description

Implemented History Service to track back Urls.

When linking to a specific screen that requires back button functionality, a queryparam (backUrl) should be passed from source to the target route.

For example, the 'view transcript screen' can be reached from the 'user record screen' and from the 'transcript search screen'.

http://localhost:3000/admin/transcripts/1?backUrl=%2Fadmin%2Ftranscripts 
http://localhost:3000/admin/transcripts/7?backUrl=%2Fadmin%2Fusers%2F1 

The app component listens for any url changes containing a backUrl parameter and stores it in history service


