### PR TITLE
fixes console warnings on multiple pages

### DIFF
--- a/src/app/core/components/common/details-table/details-table.component.html
+++ b/src/app/core/components/common/details-table/details-table.component.html
@@ -16,7 +16,7 @@
         <dd class="govuk-summary-list__value">
           <!-- check if value is an array of links -->
           @if (getLinkArray(detail.value).length) {
-            @for (item of getLinkArray(detail.value); track item.value) {
+            @for (item of getLinkArray(detail.value); track item.value ? item.value : item) {
               @if (item.href) {
                 <a [routerLink]="item.href" class="govuk-link">{{ item.value }}</a>
                 @if (item.caption) {
@@ -24,6 +24,7 @@
                 }
                 <br />
               } @else {
+                <!-- Handles flat arrays -->
                 <span>{{ item }} </span>
               }
             }


### PR DESCRIPTION
Conditionally tracking by item.value in details table

- change aim to fix console warnings appearing on;
- http://localhost:3000/case/1/transcripts/1
- http://localhost:3000/case/1/hearing/1/transcripts/1