### PR TITLE
DMP-4005/6 - deletion banner logic change for audio/transcription

### DIFF
--- a/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/transcript-requests-spec.cy.js
@@ -341,7 +341,7 @@ describe('Admin - Transcript requests', () => {
       cy.get('.govuk-notification-banner__body').contains('unhide').should('exist');
 
       cy.get('.govuk-list').should('contain', 'Hidden by - Eric Bristow');
-      cy.get('.govuk-list').should('contain', 'Reason - Public interest immunity');
+      cy.get('.govuk-list').should('contain', 'Reason - Other reason to hide only');
       cy.get('.govuk-list').should('contain', 'Ticket Reference 1232 - This is a comment');
     });
 

--- a/darts-api-stub/admin/transcriptions/transcription-documents.js
+++ b/darts-api-stub/admin/transcriptions/transcription-documents.js
@@ -173,7 +173,7 @@ let updatedDocs = [];
 router.get('/reset', (req, res) => {
   transcription = { ...defaultTranscription };
   updatedDocs = [];
-  console.log('reset transcription documents');
+
   res.sendStatus(202);
 });
 
@@ -201,12 +201,15 @@ router.get('/:transcription_document_id', (req, res) => {
   } else if ((id === '1' || id === '11') && !updatedDocs.includes(parseInt(id))) {
     //For hidden but not marked for deletion scenarios
     transcription.is_hidden = true;
+    transcription.admin_action.reason_id = 5;
     transcription.admin_action.is_marked_for_manual_deletion = false;
   } else if (updatedDocs.includes(parseInt(id))) {
     transcription.is_hidden = false;
+    transcription.admin_action.reason_id = 5;
     transcription.admin_action.is_marked_for_manual_deletion = false;
   } else if (!updatedDocs.includes(transcription.id)) {
     transcription.is_hidden = true;
+    transcription.admin_action.reason_id = 1;
     transcription.admin_action.is_marked_for_manual_deletion = true;
   }
 

--- a/src/app/admin/components/audio-file/audio-file.component.html
+++ b/src/app/admin/components/audio-file/audio-file.component.html
@@ -10,7 +10,7 @@
     @if (isAdmin) {
       <button class="govuk-button govuk-button--secondary" (click)="hideOrUnhideFile(data.audioFile)">
         @if (data.audioFile.isHidden) {
-          @if (data.audioFile.adminAction?.isMarkedForManualDeletion) {
+          @if (data.hiddenFileBanner?.isMarkedForDeletion) {
             Unmark for deletion and unhide
           } @else {
             Unhide

--- a/src/app/admin/components/audio-file/audio-file.component.spec.ts
+++ b/src/app/admin/components/audio-file/audio-file.component.spec.ts
@@ -1,4 +1,6 @@
+import { HiddenFileBanner } from '@admin-types/common/hidden-file-banner';
 import { FileHide } from '@admin-types/hidden-reasons/file-hide';
+import { HiddenReason } from '@admin-types/hidden-reasons/hidden-reason';
 import { AudioFile } from '@admin-types/index';
 import { DatePipe } from '@angular/common';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
@@ -185,16 +187,17 @@ describe('AudioFileComponent', () => {
     });
 
     it('maps the audioFile details to a HiddenFileBanner', fakeAsync(() => {
-      const expected = {
+      const expected: HiddenFileBanner = {
         id: 100,
         isHidden: false,
-        isMarkedForManualDeletion: false,
+        isApprovedForManualDeletion: false,
         markedForManualDeletionBy: 'full name',
         hiddenByName: 'full name',
         hiddenReason: 'because of reasons',
         ticketReference: 'refy ref',
         comments: 'commenty comment',
         fileType: 'audio_file',
+        isMarkedForDeletion: false,
       };
 
       component.fileBanner$.subscribe((result) => {
@@ -258,12 +261,15 @@ describe('AudioFileComponent', () => {
     }));
 
     it('"Unmark for manual deletion and" text when marked for manual deletion and hidden', fakeAsync(() => {
+      jest
+        .spyOn(component.transcriptionAdminService, 'getHiddenReason')
+        .mockReturnValue(of({ displayName: 'reason 1', markedForDeletion: true } as HiddenReason));
       jest.spyOn(component.transformedMediaService, 'getMediaById').mockReturnValue(
         of({
           ...audioFile,
           isHidden: true,
           adminAction: audioFile.adminAction
-            ? { ...audioFile.adminAction, isMarkedForManualDeletion: true }
+            ? { ...audioFile.adminAction, isApprovedForManualDeletion: false }
             : undefined,
         })
       );

--- a/src/app/admin/components/audio-file/audio-file.component.ts
+++ b/src/app/admin/components/audio-file/audio-file.component.ts
@@ -7,17 +7,17 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { BreadcrumbComponent } from '@common/breadcrumb/breadcrumb.component';
 import { ExpiredBannerComponent } from '@common/expired-banner/expired-banner.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
+import { HiddenFileBannerComponent } from '@common/hidden-file-banner/hidden-file-banner.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { BreadcrumbDirective } from '@directives/breadcrumb.directive';
 import { TabDirective } from '@directives/tab.directive';
 import { CaseService } from '@services/case/case.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
 import { TransformedMediaService } from '@services/transformed-media/transformed-media.service';
+import { UserAdminService } from '@services/user-admin/user-admin.service';
 import { UserService } from '@services/user/user.service';
 import { DateTime } from 'luxon';
 import { Observable, forkJoin, map, of, shareReplay, switchMap } from 'rxjs';
-import { HiddenFileBannerComponent } from '../common/hidden-file-banner/hidden-file-banner.component';
-import { UserAdminService } from './../../services/user-admin/user-admin.service';
 import { AdvancedAudioFileDetailsComponent } from './advanced-audio-file-details/advanced-audio-file-details.component';
 import { BasicAudioFileDetailsComponent } from './basic-audio-file-details/basic-audio-file-details.component';
 
@@ -141,8 +141,9 @@ export class AudioFileComponent {
                 (reason): HiddenFileBanner => ({
                   id: audioFile.id,
                   isHidden: audioFile.isHidden,
-                  isMarkedForManualDeletion: audioFile.adminAction?.isMarkedForManualDeletion ?? false,
+                  isApprovedForManualDeletion: audioFile.adminAction?.isMarkedForManualDeletion ?? false,
                   markedForManualDeletionBy: audioFile.adminAction?.markedForManualDeletionBy ?? 'Unknown',
+                  isMarkedForDeletion: reason?.markedForDeletion ?? false,
                   hiddenReason: reason?.displayName ?? 'Unknown',
                   hiddenByName: audioFile.adminAction?.hiddenByName ?? 'Unknown',
                   ticketReference: audioFile.adminAction?.ticketReference ?? 'Unknown',

--- a/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.html
+++ b/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.html
@@ -1,6 +1,6 @@
 @if (file?.isHidden) {
   <app-notification-banner [heading]="heading" class="no-max-width">
-    @if (file?.isMarkedForManualDeletion) {
+    @if (file?.isMarkedForDeletion) {
       DARTS user cannot view this file.
       @if (userService.isAdmin()) {
         You can
@@ -13,7 +13,7 @@
       }
     }
     <ul class="govuk-list">
-      @if (file?.isMarkedForManualDeletion) {
+      @if (file?.isMarkedForDeletion) {
         <li><strong>Marked for manual deletion by</strong> - {{ file?.markedForManualDeletionBy }}</li>
       } @else {
         <li><strong>Hidden by</strong> - {{ file?.hiddenByName }}</li>

--- a/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.spec.ts
+++ b/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.spec.ts
@@ -19,7 +19,8 @@ describe('HiddenFileBannerComponent', () => {
     component.file = {
       id: 1,
       isHidden: true,
-      isMarkedForManualDeletion: true,
+      isApprovedForManualDeletion: false,
+      isMarkedForDeletion: true,
       markedForManualDeletionBy: 'me',
       hiddenByName: 'you',
       hiddenReason: 'because',
@@ -36,12 +37,12 @@ describe('HiddenFileBannerComponent', () => {
 
   describe('heading', () => {
     it('should return the correct heading when the file is marked for manual deletion', () => {
-      component.file = { isMarkedForManualDeletion: true } as HiddenFileBanner;
+      component.file = { isMarkedForDeletion: true } as HiddenFileBanner;
       expect(component.heading).toBe('This file is hidden in DARTS and is marked for manual deletion');
     });
 
     it('should return the correct heading when the file is not marked for manual deletion', () => {
-      component.file = { isMarkedForManualDeletion: false } as HiddenFileBanner;
+      component.file = { isMarkedForDeletion: false } as HiddenFileBanner;
       expect(component.heading).toBe('This file is hidden in DARTS');
     });
   });
@@ -74,7 +75,7 @@ describe('HiddenFileBannerComponent', () => {
     beforeEach(() => {
       if (component.file) {
         component.file.isHidden = true;
-        component.file.isMarkedForManualDeletion = false;
+        component.file.isMarkedForDeletion = false;
       }
       fixture.detectChanges();
     });
@@ -106,7 +107,7 @@ describe('HiddenFileBannerComponent', () => {
     beforeEach(() => {
       if (component.file) {
         component.file.isHidden = true;
-        component.file.isMarkedForManualDeletion = true;
+        component.file.isMarkedForDeletion = true;
       }
       fixture.detectChanges();
     });
@@ -139,7 +140,7 @@ describe('HiddenFileBannerComponent', () => {
     beforeEach(() => {
       if (component.file) {
         component.file.isHidden = true;
-        component.file.isMarkedForManualDeletion = true;
+        component.file.isMarkedForDeletion = true;
       }
       component.userService.isAdmin = jest.fn().mockReturnValue(false);
       fixture.detectChanges();
@@ -165,7 +166,7 @@ describe('HiddenFileBannerComponent', () => {
     beforeEach(() => {
       if (component.file) {
         component.file.isHidden = true;
-        component.file.isMarkedForManualDeletion = false;
+        component.file.isMarkedForDeletion = false;
       }
       component.userService.isAdmin = jest.fn().mockReturnValue(false);
       fixture.detectChanges();

--- a/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.ts
+++ b/src/app/admin/components/common/hidden-file-banner/hidden-file-banner.component.ts
@@ -20,7 +20,7 @@ export class HiddenFileBannerComponent {
   router = inject(Router);
 
   get heading() {
-    return this.file?.isMarkedForManualDeletion
+    return this.file?.isMarkedForDeletion
       ? 'This file is hidden in DARTS and is marked for manual deletion'
       : 'This file is hidden in DARTS';
   }

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.html
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.html
@@ -14,7 +14,7 @@
     @if (userService.isAdmin()) {
       <button class="govuk-button govuk-button--secondary" (click)="hideOrUnhideFile(vm.document)">
         @if (vm.document.isHidden) {
-          @if (vm.document.adminAction?.isMarkedForManualDeletion) {
+          @if (vm.fileBanner?.isMarkedForDeletion) {
             Unmark for deletion and unhide
           } @else {
             Unhide

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.spec.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.spec.ts
@@ -30,10 +30,12 @@ const hiddenReasons = [
   {
     id: 1,
     displayName: 'Reason 1',
+    markedForDeletion: false,
   },
   {
     id: 2,
     displayName: 'Reason 2',
+    markedForDeletion: false,
   },
 ] as unknown as HiddenReason[];
 
@@ -175,8 +177,9 @@ describe('ViewTranscriptionDocumentComponent', () => {
         expect(data.fileBanner).toEqual({
           id: mockTranscriptionDocument.transcriptionId,
           isHidden: mockTranscriptionDocument.isHidden,
-          isMarkedForManualDeletion: mockTranscriptionDocument.adminAction?.isMarkedForManualDeletion,
+          isApprovedForManualDeletion: mockTranscriptionDocument.adminAction?.isMarkedForManualDeletion,
           markedForManualDeletionBy: mockTranscriptionDocument.adminAction?.markedForManualDeletionBy,
+          isMarkedForDeletion: hiddenReasons[0]?.markedForDeletion,
           hiddenReason: hiddenReasons[0]?.displayName,
           hiddenByName: mockTranscriptionDocument.adminAction?.hiddenByName,
           ticketReference: mockTranscriptionDocument.adminAction?.ticketReference,

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
@@ -98,8 +98,9 @@ export class ViewTranscriptionDocumentComponent {
             (reason): HiddenFileBanner => ({
               id: document.transcriptionId,
               isHidden: document.isHidden,
-              isMarkedForManualDeletion: document.adminAction?.isMarkedForManualDeletion ?? false,
+              isApprovedForManualDeletion: document.adminAction?.isMarkedForManualDeletion ?? false,
               markedForManualDeletionBy: document.adminAction?.markedForManualDeletionBy ?? 'Unknown',
+              isMarkedForDeletion: reason?.markedForDeletion ?? false,
               hiddenReason: reason?.displayName ?? 'Unknown',
               hiddenByName: document.adminAction?.hiddenByName ?? 'Unknown',
               ticketReference: document.adminAction?.ticketReference ?? 'Unknown',

--- a/src/app/admin/models/common/hidden-file-banner.ts
+++ b/src/app/admin/models/common/hidden-file-banner.ts
@@ -1,7 +1,8 @@
 export type HiddenFileBanner = {
   id: number;
   isHidden: boolean;
-  isMarkedForManualDeletion: boolean;
+  isApprovedForManualDeletion: boolean;
+  isMarkedForDeletion: boolean;
   markedForManualDeletionBy: string;
   hiddenByName: string;
   hiddenReason: string;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-4005
https://tools.hmcts.net/jira/browse/DMP-4006

Deletion banner logic changed so it looks at mapped reason.marked_for_deletion rather than is_marked_for_deletion against audio/transcript file

Renamed isMarkedForManualDeletion to isApprovedForManualDeletion for clearer meaning