### PR TITLE
DMP-3660 & DMP-3910 Add event text obfuscation flow

### DIFF
--- a/cypress/e2e/functional/admin-portal/event-details-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/event-details-spec.cy.js
@@ -1,0 +1,28 @@
+import 'cypress-axe';
+import '../commands';
+
+describe('Admin - Event details', () => {
+  beforeEach(() => {
+    cy.login('admin');
+    cy.visit('/admin/events/111');
+    cy.injectAxe();
+  });
+
+  it('load page', () => {
+    cy.get('h1').should('contain', '111');
+    cy.a11y();
+  });
+
+  it('obfuscates event text', () => {
+    cy.get('#obfuscate-button').click();
+    cy.get('h1').should('contain', 'Are you sure you want to obfuscate the event text?');
+    cy.a11y();
+    cy.get('#confirm-button').click();
+    cy.get('#success-message').should('contain', 'Event text successfully obfuscated ');
+    cy.get('#warning-message').should('contain', 'This event text has been anonymised in line with HMCTS policy.');
+    cy.get('app-basic-event-details').should('contain', 'This event has been anonymised in line with HMCTS policy ');
+    cy.a11y();
+
+    cy.request('/api/admin/events/reset');
+  });
+});

--- a/darts-api-stub/admin/events/events.js
+++ b/darts-api-stub/admin/events/events.js
@@ -70,6 +70,18 @@ router.post('/search', (req, res) => {
   res.send(events);
 });
 
+router.post('/obfuscate', (req, res) => {
+  const ids = req.body.eve_ids;
+  ids.forEach((id) => {
+    const eventsIndex = events.findIndex((event) => event.id === id);
+    const viewEventIndex = viewEvents.findIndex((event) => event.id === id);
+
+    events[eventsIndex].is_data_anonymised = true;
+    viewEvents[viewEventIndex].is_data_anonymised = true;
+  });
+  res.status(200).send();
+});
+
 const viewEvents = events.map((event) => ({
   ...event,
   event_mapping: {
@@ -78,7 +90,6 @@ const viewEvents = events.map((event) => ({
   is_log_entry: false,
   version: 'v1',
   is_data_anonymised: false,
-  case_expired_at: '2024-06-01T13:00:00Z',
   created_by: 1,
   last_modified_by: 2,
   last_modified_at: '2024-06-01T13:00:00Z',
@@ -88,17 +99,24 @@ const viewEvents = events.map((event) => ({
   is_current: true,
 }));
 
+router.get('/reset', (req, res) => {
+  events.forEach((event) => {
+    event.is_data_anonymised = false;
+  });
+
+  viewEvents.forEach((event) => {
+    event.is_data_anonymised = false;
+  });
+
+  res.status(200).send();
+});
+
 router.get('/:id', (req, res) => {
   const id = Number(req.params.id);
   const viewEvent = viewEvents.find((event) => event.id === Number(req.params.id));
   if (!viewEvent) {
     return res.status(404).send('Event not found');
   }
-
-  if (id === 333) {
-    return res.send({ ...viewEvent, is_data_anonymised: true });
-  }
-
   res.send(viewEvent);
 });
 

--- a/src/app/admin/admin.routes.ts
+++ b/src/app/admin/admin.routes.ts
@@ -149,7 +149,16 @@ export const ADMIN_ROUTES: Routes = [
     loadComponent: () =>
       import('./components/events/view-event/view-event.component').then((c) => c.ViewEventComponent),
   },
-
+  {
+    path: 'admin/events/:id/obfuscate',
+    title: 'DARTS Admin Obfuscate Event Text',
+    data: { allowedRoles: ['SUPER_ADMIN'] },
+    loadComponent: () =>
+      import('./components/events/obfuscate-event-text/obfuscate-event-text.component').then(
+        (c) => c.ObfuscateEventTextComponent
+      ),
+    canActivate: [manualDeletionGuard], // manual deletion feature flag must be enabled
+  },
   {
     path: 'admin/audio-file/:id',
     title: 'DARTS Admin View Audio File',
@@ -353,7 +362,7 @@ export const ADMIN_ROUTES: Routes = [
   const updatedRoute = {
     ...route,
     resolve: { userState: () => inject(UserService).userProfile$ },
-    canActivate: [authGuard],
+    canActivate: route.canActivate ? [authGuard, ...route.canActivate] : [authGuard],
   };
 
   if (route.path && route.path.startsWith('admin/file-deletion')) {

--- a/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.spec.ts
+++ b/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.spec.ts
@@ -36,7 +36,6 @@ describe('AdvancedEventDetailsComponent', () => {
     createdById: 0,
     lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
     lastModifiedById: 0,
-    caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
     isCurrentVersion: true,
   };
 

--- a/src/app/admin/components/events/basic-event-details/basic-event-details.component.html
+++ b/src/app/admin/components/events/basic-event-details/basic-event-details.component.html
@@ -10,7 +10,7 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Text</dt>
     <dd class="govuk-summary-list__value">
-      {{ event().text }}
+      {{ event().isDataAnonymised ? 'This event has been anonymised in line with HMCTS policy' : event().text }}
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/src/app/admin/components/events/basic-event-details/basic-event-details.component.spec.ts
+++ b/src/app/admin/components/events/basic-event-details/basic-event-details.component.spec.ts
@@ -9,23 +9,17 @@ describe('BasicEventDetailsComponent', () => {
   let component: BasicEventDetailsComponent;
   let fixture: ComponentFixture<BasicEventDetailsComponent>;
 
-  const event = {
-    id: 0,
-    text: 'text',
-    eventMapping: {
-      name: 'eventMapping',
-    },
-    courthouse: {
-      displayName: 'courthouse',
-    },
-    courtroom: {
-      name: 'courtroom',
-    },
-    createdAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
+  const mockEvent: Event = {
+    isDataAnonymised: false,
+    text: 'this event text is not anonymised',
+    eventMapping: { name: 'name' },
+    courthouse: { displayName: 'courthouse' },
+    courtroom: { name: 'courtroom' },
+    eventTs: DateTime.fromISO('2024-05-05T11:00:00Z'),
   } as Event;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  const setup = (event: Event) => {
+    TestBed.configureTestingModule({
       imports: [BasicEventDetailsComponent],
       providers: [{ provide: DatePipe }],
     }).compileComponents();
@@ -34,9 +28,22 @@ describe('BasicEventDetailsComponent', () => {
     fixture.componentRef.setInput('event', event);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  };
 
   it('should create', () => {
+    setup(mockEvent);
     expect(component).toBeTruthy();
+  });
+
+  describe('anonymised text', () => {
+    it('show anonymised text when event is anonymised', () => {
+      setup({ ...mockEvent, isDataAnonymised: true });
+      expect(fixture.nativeElement.textContent).toContain('This event has been anonymised in line with HMCTS policy');
+    });
+
+    it('show event text when event is not anonymised', () => {
+      setup({ ...mockEvent, isDataAnonymised: false });
+      expect(fixture.nativeElement.textContent).toContain('this event text is not anonymised');
+    });
   });
 });

--- a/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.html
+++ b/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.html
@@ -1,0 +1,17 @@
+@let e = event();
+
+@if (e) {
+  <app-govuk-heading>Are you sure you want to obfuscate the event text?</app-govuk-heading>
+  <p class="govuk-body">The following event text will be irreversibly obfuscated</p>
+
+  <p id="event-text" class="govuk-body">
+    {{ e.text }}
+  </p>
+
+  <div class="govuk-button-group">
+    <button id="confirm-button" class="govuk-button" type="button" (click)="onContinue()">Continue</button>
+    <a [routerLink]="['../']" class="govuk-link">Cancel</a>
+  </div>
+} @else {
+  <app-loading />
+}

--- a/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.spec.ts
+++ b/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+
+import { Event } from '@admin-types/events';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { LoadingComponent } from '@common/loading/loading.component';
+import { EventsFacadeService } from '@facades/events/events-facade.service';
+import { HeaderService } from '@services/header/header.service';
+import { of } from 'rxjs';
+import { ObfuscateEventTextComponent } from './obfuscate-event-text.component';
+
+const mockEvent: Event = { text: 'Unobfuscated text' } as Event;
+
+describe('ObfuscateEventTextComponent', () => {
+  let component: ObfuscateEventTextComponent;
+  let fixture: ComponentFixture<ObfuscateEventTextComponent>;
+
+  const setup = (event: Event) => {
+    TestBed.configureTestingModule({
+      imports: [ObfuscateEventTextComponent],
+      providers: [
+        {
+          provide: EventsFacadeService,
+          useValue: {
+            getEvent: jest.fn().mockReturnValue(of(event)),
+            obfuscateEventText: jest.fn().mockReturnValue(of({})),
+          },
+        },
+        { provide: HeaderService, useValue: { hideNavigation: jest.fn() } },
+        provideRouter([]),
+      ],
+    });
+
+    fixture = TestBed.createComponent(ObfuscateEventTextComponent);
+    fixture.componentRef.setInput('id', '1');
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  it('should create', () => {
+    setup(mockEvent);
+    expect(component.id()).toBe(1);
+    expect(component.event()).toEqual(mockEvent);
+    expect(component).toBeTruthy();
+    expect(component.headerService.hideNavigation).toHaveBeenCalled();
+  });
+
+  it('should call obfuscateEventText on continue', fakeAsync(() => {
+    setup(mockEvent);
+    const obfuscateEventTextSpy = jest.spyOn(component.eventsFacadeService, 'obfuscateEventText');
+    const navigateBackToEventSpy = jest.spyOn(component, 'navigateBackToEvent').mockImplementation(() => {});
+
+    component.onContinue();
+    tick();
+
+    expect(obfuscateEventTextSpy).toHaveBeenCalledWith(1);
+    expect(navigateBackToEventSpy).toHaveBeenCalled();
+  }));
+
+  it('should navigate back to event', () => {
+    setup(mockEvent);
+    const routerSpy = jest.spyOn(component.router, 'navigate');
+
+    component.navigateBackToEvent();
+
+    expect(routerSpy).toHaveBeenCalledWith(['/admin/events', 1], { queryParams: { isObfuscationSuccess: true } });
+  });
+
+  it('show loading component while loading', () => {
+    setup(null as unknown as Event);
+    expect(fixture.debugElement.query(By.directive(LoadingComponent))).toBeTruthy();
+  });
+
+  it('hide loading component after loading', () => {
+    setup(mockEvent);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.directive(LoadingComponent))).toBeFalsy();
+  });
+
+  it('display event text', () => {
+    setup(mockEvent);
+    fixture.detectChanges();
+    const textElement = fixture.debugElement.query(By.css('#event-text')).nativeElement;
+    expect(textElement.textContent).toContain('Unobfuscated text');
+  });
+});

--- a/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.ts
+++ b/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.ts
@@ -1,0 +1,37 @@
+import { Component, inject, input, numberAttribute, OnInit } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Router, RouterLink } from '@angular/router';
+import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
+import { LoadingComponent } from '@common/loading/loading.component';
+import { EventsFacadeService } from '@facades/events/events-facade.service';
+import { HeaderService } from '@services/header/header.service';
+import { switchMap } from 'rxjs';
+
+@Component({
+  selector: 'app-obfuscate-event-text',
+  standalone: true,
+  imports: [GovukHeadingComponent, RouterLink, LoadingComponent],
+  templateUrl: './obfuscate-event-text.component.html',
+  styleUrl: './obfuscate-event-text.component.scss',
+})
+export class ObfuscateEventTextComponent implements OnInit {
+  router = inject(Router);
+  headerService = inject(HeaderService);
+  eventsFacadeService = inject(EventsFacadeService);
+
+  id = input(0, { transform: numberAttribute });
+
+  event = toSignal(toObservable(this.id).pipe(switchMap((id) => this.eventsFacadeService.getEvent(id))));
+
+  ngOnInit() {
+    this.headerService.hideNavigation();
+  }
+
+  onContinue() {
+    this.eventsFacadeService.obfuscateEventText(this.id()).subscribe(() => this.navigateBackToEvent());
+  }
+
+  navigateBackToEvent() {
+    this.router.navigate(['/admin/events', this.id()], { queryParams: { isObfuscationSuccess: true } });
+  }
+}

--- a/src/app/admin/components/events/view-event/view-event.component.html
+++ b/src/app/admin/components/events/view-event/view-event.component.html
@@ -3,11 +3,22 @@
 @let e = event();
 
 @if (e) {
-  @if (e.isDataAnonymised) {
-    <app-expired-banner [expiryDate]="e.caseExpiredAt" />
+  @if (isObfuscationSuccess()) {
+    <app-govuk-banner type="success"> Event text successfully obfuscated </app-govuk-banner>
   }
 
-  <app-govuk-heading caption="Event">{{ e.id }}</app-govuk-heading>
+  @if (showAnonymisedTextBanner()) {
+    <app-govuk-banner type="warning"> This event text has been anonymised in line with HMCTS policy. </app-govuk-banner>
+  }
+
+  <div class="heading-button-container">
+    <app-govuk-heading caption="Event">{{ e.id }}</app-govuk-heading>
+    @if (showObfuscateButton()) {
+      <button id="obfuscate-button" class="govuk-button govuk-button--secondary" (click)="onObfuscateEventText()">
+        Obfuscate event text
+      </button>
+    }
+  </div>
 
   @if (userService.isAdmin()) {
     <app-tabs>

--- a/src/app/admin/components/events/view-event/view-event.component.scss
+++ b/src/app/admin/components/events/view-event/view-event.component.scss
@@ -1,0 +1,5 @@
+.heading-button-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}

--- a/src/app/admin/components/events/view-event/view-event.component.ts
+++ b/src/app/admin/components/events/view-event/view-event.component.ts
@@ -1,13 +1,16 @@
-import { Component, inject, input, numberAttribute } from '@angular/core';
+import { Component, computed, inject, input, numberAttribute } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ExpiredBannerComponent } from '@common/expired-banner/expired-banner.component';
+import { GovukBannerComponent } from '@common/govuk-banner/govuk-banner.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { TabDirective } from '@directives/tab.directive';
 import { EventsFacadeService } from '@facades/events/events-facade.service';
+import { FeatureFlagService } from '@services/app-config/feature-flag.service';
 import { UserService } from '@services/user/user.service';
+import { optionalStringToBooleanOrNull } from '@utils/index';
 import { switchMap } from 'rxjs';
 import { AdvancedEventDetailsComponent } from '../advanced-event-details/advanced-event-details.component';
 import { BasicEventDetailsComponent } from '../basic-event-details/basic-event-details.component';
@@ -24,6 +27,7 @@ import { BasicEventDetailsComponent } from '../basic-event-details/basic-event-d
     BasicEventDetailsComponent,
     AdvancedEventDetailsComponent,
     ExpiredBannerComponent,
+    GovukBannerComponent,
   ],
   templateUrl: './view-event.component.html',
   styleUrl: './view-event.component.scss',
@@ -31,8 +35,22 @@ import { BasicEventDetailsComponent } from '../basic-event-details/basic-event-d
 export class ViewEventComponent {
   eventsFacadeService = inject(EventsFacadeService);
   userService = inject(UserService);
+  router = inject(Router);
+  isManualDeletionEnabled = inject(FeatureFlagService).isManualDeletionEnabled();
 
   id = input(0, { transform: numberAttribute });
+  isObfuscationSuccess = input(null, { transform: optionalStringToBooleanOrNull });
 
   event = toSignal(toObservable(this.id).pipe(switchMap((id) => this.eventsFacadeService.getEvent(id))));
+
+  // manual deletion feature flag must be enabled, user must be SUPER_ADMIN, event is not already obfuscated
+  showObfuscateButton = computed(
+    () => this.isManualDeletionEnabled && this.userService.isAdmin() && !this.event()?.isDataAnonymised
+  );
+
+  showAnonymisedTextBanner = computed(() => this.event()?.isDataAnonymised);
+
+  onObfuscateEventText() {
+    this.router.navigate(['/admin/events', this.id(), 'obfuscate']);
+  }
 }

--- a/src/app/admin/facades/events/events-facade.service.spec.ts
+++ b/src/app/admin/facades/events/events-facade.service.spec.ts
@@ -74,7 +74,6 @@ describe('EventsFacadeService', () => {
         eventTs: DateTime.fromISO('2024-05-05T11:00:00Z'),
         createdAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
         lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
-        caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
         isCurrentVersion: false,
       };
 
@@ -103,5 +102,15 @@ describe('EventsFacadeService', () => {
       });
       tick();
     }));
+  });
+
+  describe('obfuscateEventText', () => {
+    it('calls events service to obfuscate event text', () => {
+      eventsService.obfuscateEventTexts = jest.fn();
+
+      service.obfuscateEventText(1);
+
+      expect(eventsService.obfuscateEventTexts).toHaveBeenCalledWith([1]);
+    });
   });
 });

--- a/src/app/admin/facades/events/events-facade.service.ts
+++ b/src/app/admin/facades/events/events-facade.service.ts
@@ -19,6 +19,10 @@ export class EventsFacadeService {
     return this.eventsService.getEvent(id).pipe(switchMap((event) => this.getAssociatedData(event)));
   }
 
+  obfuscateEventText(id: number) {
+    return this.eventsService.obfuscateEventTexts([id]);
+  }
+
   private getAssociatedData(event: Event) {
     const userIds = [event.createdById, event.lastModifiedById];
 

--- a/src/app/admin/models/events/event.ts
+++ b/src/app/admin/models/events/event.ts
@@ -31,6 +31,5 @@ export type Event = {
   lastModifiedAt: DateTime;
   lastModifiedById: number;
   lastModifiedBy?: User;
-  caseExpiredAt: DateTime;
   isCurrentVersion: boolean;
 };

--- a/src/app/admin/services/events/events.service.spec.ts
+++ b/src/app/admin/services/events/events.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
@@ -52,7 +52,6 @@ describe('EventsService', () => {
         created_by: 1,
         last_modified_at: '2024-05-05T11:00:00Z',
         last_modified_by: 1,
-        case_expired_at: '2024-05-05T11:00:00Z',
       };
 
       let event;
@@ -87,7 +86,6 @@ describe('EventsService', () => {
         createdById: 1,
         lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
         lastModifiedById: 1,
-        caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
       };
 
       const req = httpMock.expectOne('/api/admin/events/1');
@@ -97,5 +95,20 @@ describe('EventsService', () => {
 
       expect(event).toEqual(expectedEvent);
     });
+  });
+
+  describe('#obfuscateEventTexts', () => {
+    it('should send a POST request to obfuscate event texts', fakeAsync(() => {
+      const eventIds = [1, 2, 3];
+
+      service.obfuscateEventTexts(eventIds).subscribe();
+      tick();
+
+      const req = httpMock.expectOne('/api/admin/events/obfuscate');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ eve_ids: eventIds });
+
+      req.flush(null);
+    }));
   });
 });

--- a/src/app/admin/services/events/events.service.ts
+++ b/src/app/admin/services/events/events.service.ts
@@ -15,6 +15,10 @@ export class EventsService {
     return this.http.get<EventData>(`/api/admin/events/${id}`).pipe(map((event) => this.mapEventDataToEvent(event)));
   }
 
+  obfuscateEventTexts(ids: number[]) {
+    return this.http.post<void>('/api/admin/events/obfuscate', { eve_ids: ids });
+  }
+
   mapEventDataToEvent(event: EventData): Event {
     return {
       id: event.id,
@@ -43,7 +47,6 @@ export class EventsService {
       createdById: event.created_by,
       lastModifiedAt: DateTime.fromISO(event.last_modified_at),
       lastModifiedById: event.last_modified_by,
-      caseExpiredAt: DateTime.fromISO(event.case_expired_at),
       isCurrentVersion: event.is_current,
     };
   }


### PR DESCRIPTION
### Jira link

[DMP-3660](https://tools.hmcts.net/jira/browse/DMP-3660)
[DMP-3910](https://tools.hmcts.net/jira/browse/DMP-3910)

### Change description

- Add **Obfuscate event text** button to event details screen
- Add success and warning banners
- Hide feature behind isManualDeletionEnabled() feature flag
- Add route protection to obfuscation screen based on feature flag
- Remove expired case banner

Note the `POST /admin/events/obfuscate` endpoint is still in progress