### PR TITLE
DMP-4084: Add 'Is current' to event advanced details

### DIFF
--- a/cypress/e2e/functional/admin-portal/search-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/search-spec.cy.js
@@ -137,6 +137,7 @@ describe('Admin - Search screen', () => {
     cy.get('dt').contains('Event Handler').next('dd').should('contain', 'StandardEventHandler');
     cy.get('dt').contains('Reporting restriction?').next('dd').should('contain', 'No');
     cy.get('dt').contains('Log entry?').next('dd').should('contain', 'No');
+    cy.get('dt').contains('Is current?').next('dd').should('contain', 'Yes');
 
     // Version data
     cy.get('dt').contains('Version').next('dd').should('contain', 'v1');

--- a/darts-api-stub/admin/events/events.js
+++ b/darts-api-stub/admin/events/events.js
@@ -85,6 +85,7 @@ const viewEvents = events.map((event) => ({
   documentum_id: '123456',
   message_id: '654321',
   source_id: 'source123',
+  is_current: true,
 }));
 
 router.get('/:id', (req, res) => {

--- a/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.html
+++ b/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.html
@@ -49,6 +49,12 @@
       {{ event().isLogEntry ? 'Yes' : 'No' }}
     </dd>
   </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Is current?</dt>
+    <dd class="govuk-summary-list__value">
+      {{ event().isCurrentVersion ? 'Yes' : 'No' }}
+    </dd>
+  </div>
 </dl>
 
 <app-govuk-heading class="no-margin border-bottom" tag="h2" size="m">Version data</app-govuk-heading>

--- a/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.spec.ts
+++ b/src/app/admin/components/events/advanced-event-details/advanced-event-details.component.spec.ts
@@ -37,6 +37,7 @@ describe('AdvancedEventDetailsComponent', () => {
     lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
     lastModifiedById: 0,
     caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
+    isCurrentVersion: true,
   };
 
   beforeEach(async () => {

--- a/src/app/admin/components/events/view-event/view-event.component.spec.ts
+++ b/src/app/admin/components/events/view-event/view-event.component.spec.ts
@@ -42,6 +42,7 @@ const mockEvent: Event = {
   lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
   lastModifiedById: 0,
   caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
+  isCurrentVersion: true,
 };
 
 describe('ViewEventComponent', () => {

--- a/src/app/admin/facades/events/events-facade.service.spec.ts
+++ b/src/app/admin/facades/events/events-facade.service.spec.ts
@@ -75,6 +75,7 @@ describe('EventsFacadeService', () => {
         createdAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
         lastModifiedAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
         caseExpiredAt: DateTime.fromISO('2024-05-05T11:00:00Z'),
+        isCurrentVersion: false,
       };
 
       const mockUsers: User[] = [

--- a/src/app/admin/models/events/event-data.interface.ts
+++ b/src/app/admin/models/events/event-data.interface.ts
@@ -26,4 +26,5 @@ export interface EventData {
   last_modified_at: string;
   last_modified_by: number;
   case_expired_at: string;
+  is_current: boolean;
 }

--- a/src/app/admin/models/events/event.ts
+++ b/src/app/admin/models/events/event.ts
@@ -32,4 +32,5 @@ export type Event = {
   lastModifiedById: number;
   lastModifiedBy?: User;
   caseExpiredAt: DateTime;
+  isCurrentVersion: boolean;
 };

--- a/src/app/admin/services/events/events.service.ts
+++ b/src/app/admin/services/events/events.service.ts
@@ -44,6 +44,7 @@ export class EventsService {
       lastModifiedAt: DateTime.fromISO(event.last_modified_at),
       lastModifiedById: event.last_modified_by,
       caseExpiredAt: DateTime.fromISO(event.case_expired_at),
+      isCurrentVersion: event.is_current,
     };
   }
 }


### PR DESCRIPTION
### Jira link

[DMP-4084](https://tools.hmcts.net/jira/browse/DMP-4084)

### Change description

Add 'Is current' to event advanced details

http://localhost:3000/admin/events/111

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/7ca070aa-17bb-4afa-b8f7-a2f7fb9b9d5b">
