### PR TITLE
DMP-4121: Fix last playing event highlight in audio view

### DIFF
--- a/src/app/portal/components/audios/audio-view/audio-view.component.ts
+++ b/src/app/portal/components/audios/audio-view/audio-view.component.ts
@@ -131,7 +131,9 @@ export class AudioViewComponent implements OnDestroy {
     return events.map((event, index) => {
       const eventStartTime = DateTime.fromISO(event.timestamp);
       // as there is no event end timestamp, use the next event's start time, if there is no next event, use the audio file's end time
-      const eventEndTime = DateTime.fromISO(events[index + 1]?.timestamp) || this.transformedMedia.endTime;
+      const eventEndTime = events[index + 1]?.timestamp
+        ? DateTime.fromISO(events[index + 1]?.timestamp)
+        : this.transformedMedia.endTime;
       const audioStartTime = this.transformedMedia.startTime;
 
       const eventAudioStartTime = eventStartTime.diff(audioStartTime, ['hours', 'minutes', 'seconds']);


### PR DESCRIPTION
### Jira link

[DMP-4121](https://tools.hmcts.net/jira/browse/DMP-4121)

### Change description

- Add null check to endtime before parsing timestamp as a Luxon DateTime