### PR TITLE
DMP-4229 - remove baseUrl, add b2c hostname

### DIFF
--- a/server/controllers/auth.ts
+++ b/server/controllers/auth.ts
@@ -12,7 +12,6 @@ function getAzureAdLogin(req: Request, res: Response): void {
   // do this whilst the page is being developed to prevent caching on the platform
   res.header('Cache-Control', 'no-store, must-revalidate');
   res.render('azuread-b2c-login.html', {
-    baseUrl: config.get('hostname'),
     hostname: config.get('authentication.azureAdB2cHostname'),
     screen: req.query.screenName,
   });

--- a/server/views/azuread-b2c-login.html
+++ b/server/views/azuread-b2c-login.html
@@ -65,7 +65,7 @@
       <div class="govuk-header__container">
         <div class="govuk-width-container">
           <div class="govuk-header__logo">
-            <a href="{{baseUrl}}" class="govuk-header__link govuk-header__link--homepage">
+            <a href="{{hostname}}" class="govuk-header__link govuk-header__link--homepage">
               <span class="govuk-header__logotype">
                 <img
                   alt="UK Government crest in white"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-4229

B2C change

Previous change created baseUrl to be referenced in b2c template. This change reverts that and uses b2c hostname. This will be the correct long term config value to be used.