### PR TITLE
DMP-4209: Add state persistence to user, group and courthouse admin search forms

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
             "prefix": "app",
             "style": "kebab-case"
           }
-        ]
+        ],
+        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]
       }
     },
     {

--- a/src/app/admin/components/courthouses/courthouse-search-form/courthouse-search-form.component.spec.ts
+++ b/src/app/admin/components/courthouses/courthouse-search-form/courthouse-search-form.component.spec.ts
@@ -12,6 +12,7 @@ describe('CourthouseSearchFormComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(CourthouseSearchFormComponent);
+    fixture.componentRef.setInput('formValues', { courthouseName: null, displayName: null, region: null });
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/admin/components/courthouses/courthouse-search-form/courthouse-search-form.component.ts
+++ b/src/app/admin/components/courthouses/courthouse-search-form/courthouse-search-form.component.ts
@@ -1,6 +1,6 @@
 import { CourthouseSearchFormValues } from '@admin-types/courthouses/courthouse-search-form-values.type';
-import { Component, EventEmitter, Output, inject } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { Component, EventEmitter, OnInit, Output, inject, input } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormErrorMessages } from '@core-types/index';
 import { optionalMaxLengthValidator } from '@validators/optional-maxlength.validator';
 
@@ -22,19 +22,21 @@ const controlErrors: FormErrorMessages = {
   templateUrl: './courthouse-search-form.component.html',
   styleUrl: './courthouse-search-form.component.scss',
 })
-export class CourthouseSearchFormComponent {
+export class CourthouseSearchFormComponent implements OnInit {
+  formValues = input.required<CourthouseSearchFormValues>();
   @Output() submitForm = new EventEmitter<CourthouseSearchFormValues>();
   @Output() clear = new EventEmitter<void>();
 
-  formDefaultValues: CourthouseSearchFormValues = { courthouseName: null, displayName: null, region: null };
-
   fb = inject(FormBuilder);
+  form!: FormGroup;
 
-  form = this.fb.group({
-    courthouseName: [this.formDefaultValues.courthouseName, [optionalMaxLengthValidator(256)]],
-    displayName: [this.formDefaultValues.displayName, [optionalMaxLengthValidator(256)]],
-    region: [this.formDefaultValues.region, [optionalMaxLengthValidator(256)]],
-  });
+  ngOnInit() {
+    this.form = this.fb.group({
+      courthouseName: [this.formValues().courthouseName, [optionalMaxLengthValidator(256)]],
+      displayName: [this.formValues().displayName, [optionalMaxLengthValidator(256)]],
+      region: [this.formValues().region, [optionalMaxLengthValidator(256)]],
+    });
+  }
 
   getFormControlErrorMessages(controlName: string): string[] {
     const errors = this.form.get(controlName)?.errors;
@@ -51,7 +53,7 @@ export class CourthouseSearchFormComponent {
   }
 
   clearSearch() {
-    this.form.reset(this.formDefaultValues);
+    this.form.reset();
     this.clear.emit();
   }
 }

--- a/src/app/admin/components/courthouses/courthouses.component.html
+++ b/src/app/admin/components/courthouses/courthouses.component.html
@@ -8,7 +8,7 @@
 </div>
 <app-govuk-heading tag="h2" size="m">Search for courthouse</app-govuk-heading>
 
-<app-courthouse-search-form (submitForm)="onSubmit($event)" (clear)="onClear()"></app-courthouse-search-form>
+<app-courthouse-search-form [formValues]="formValues()" (submitForm)="onSubmit($event)" (clear)="onClear()" />
 
 @if (results$ | async; as results) {
   <app-courthouse-search-results [results]="results" [show]="(isSubmitted$ | async) ?? false" />

--- a/src/app/admin/components/courthouses/courthouses.component.ts
+++ b/src/app/admin/components/courthouses/courthouses.component.ts
@@ -55,12 +55,14 @@ export class CourthousesComponent {
     tap(() => this.stopLoading())
   );
 
-  eff = effect(() => {
-    if (this.previousformValues()) {
-      this.search$.next(this.formValues());
-      this.isSubmitted$.next(true);
-    }
-  });
+  constructor() {
+    effect(() => {
+      if (this.previousformValues()) {
+        this.search$.next(this.formValues());
+        this.isSubmitted$.next(true);
+      }
+    });
+  }
 
   startLoading() {
     this.loading$.next(true);

--- a/src/app/admin/components/courthouses/courthouses.component.ts
+++ b/src/app/admin/components/courthouses/courthouses.component.ts
@@ -1,10 +1,11 @@
 import { CourthouseSearchFormValues } from '@admin-types/courthouses/courthouse-search-form-values.type';
 import { Courthouse } from '@admin-types/courthouses/courthouse.type';
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { CourthouseService } from '@services/courthouses/courthouses.service';
+import { FormStateService } from '@services/form-state.service';
 import { UserService } from '@services/user/user.service';
 import { BehaviorSubject, Observable, Subject, combineLatest, of, switchMap, tap } from 'rxjs';
 import { CourthouseSearchFormComponent } from './courthouse-search-form/courthouse-search-form.component';
@@ -18,9 +19,23 @@ import { CourthouseSearchResultsComponent } from './courthouse-search-results/co
   styleUrl: './courthouses.component.scss',
 })
 export class CourthousesComponent {
+  private readonly courthouseSearchKey = 'admin-courthouse-search';
+  private readonly defaultFormValues: CourthouseSearchFormValues = {
+    courthouseName: null,
+    displayName: null,
+    region: null,
+  };
+
   userService = inject(UserService);
   courthouseService = inject(CourthouseService);
   router = inject(Router);
+  formStateService = inject(FormStateService);
+
+  previousformValues = signal(
+    this.formStateService.getFormValues<CourthouseSearchFormValues>(this.courthouseSearchKey)
+  );
+
+  formValues = computed(() => this.previousformValues() ?? this.defaultFormValues);
 
   search$ = new Subject<CourthouseSearchFormValues | null>();
   loading$ = new Subject<boolean>();
@@ -40,6 +55,13 @@ export class CourthousesComponent {
     tap(() => this.stopLoading())
   );
 
+  eff = effect(() => {
+    if (this.previousformValues()) {
+      this.search$.next(this.formValues());
+      this.isSubmitted$.next(true);
+    }
+  });
+
   startLoading() {
     this.loading$.next(true);
   }
@@ -49,11 +71,13 @@ export class CourthousesComponent {
   }
 
   onSubmit(values: CourthouseSearchFormValues) {
+    this.formStateService.setFormValues(this.courthouseSearchKey, values);
     this.isSubmitted$.next(true);
     this.search$.next(values);
   }
 
   onClear() {
+    this.formStateService.clearFormValues(this.courthouseSearchKey);
     this.isSubmitted$.next(false);
     this.search$.next(null);
   }

--- a/src/app/admin/components/groups/groups.component.ts
+++ b/src/app/admin/components/groups/groups.component.ts
@@ -48,12 +48,14 @@ export class GroupsComponent {
     role: '',
   });
 
-  eff = effect(() => {
-    if (this.previousformValues()) {
-      this.form.controls.search.setValue(this.previousformValues()!.search);
-      this.form.controls.role.setValue(this.previousformValues()!.role);
-    }
-  });
+  constructor() {
+    effect(() => {
+      if (this.previousformValues()) {
+        this.form.controls.search.setValue(this.previousformValues()!.search);
+        this.form.controls.role.setValue(this.previousformValues()!.role);
+      }
+    });
+  }
 
   columns: DatatableColumn[] = [
     { name: 'Name', prop: 'name', sortable: false },

--- a/src/app/admin/components/groups/groups.component.ts
+++ b/src/app/admin/components/groups/groups.component.ts
@@ -1,6 +1,6 @@
 import { SecurityGroup } from '@admin-types/index';
-import { AsyncPipe, JsonPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, effect, inject, signal } from '@angular/core';
 import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
@@ -10,6 +10,7 @@ import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.compo
 import { LoadingComponent } from '@common/loading/loading.component';
 import { DatatableColumn } from '@core-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
+import { FormStateService } from '@services/form-state.service';
 import { GroupsService } from '@services/groups/groups.service';
 import { BehaviorSubject, combineLatest, map, shareReplay, startWith, tap } from 'rxjs';
 
@@ -22,7 +23,6 @@ import { BehaviorSubject, combineLatest, map, shareReplay, startWith, tap } from
     TableRowTemplateDirective,
     ReactiveFormsModule,
     AsyncPipe,
-    JsonPipe,
     CheckboxListComponent,
     GovukDetailsComponent,
     LoadingComponent,
@@ -32,13 +32,27 @@ import { BehaviorSubject, combineLatest, map, shareReplay, startWith, tap } from
   styleUrl: './groups.component.scss',
 })
 export class GroupsComponent {
+  private readonly groupSearchFormKey = 'admin-groups-search';
+
   groupsService = inject(GroupsService);
   router = inject(Router);
   fb = inject(FormBuilder);
+  formStateService = inject(FormStateService);
+
+  previousformValues = signal(
+    this.formStateService.getFormValues<{ search: string; role: string }>(this.groupSearchFormKey)
+  );
 
   form = this.fb.group({
     search: '',
-    roles: [],
+    role: '',
+  });
+
+  eff = effect(() => {
+    if (this.previousformValues()) {
+      this.form.controls.search.setValue(this.previousformValues()!.search);
+      this.form.controls.role.setValue(this.previousformValues()!.role);
+    }
   });
 
   columns: DatatableColumn[] = [
@@ -58,6 +72,7 @@ export class GroupsComponent {
     this.rolesFormControl.valueChanges.pipe(startWith('')),
   ]).pipe(
     map(([groups, search, role]) => {
+      this.formStateService.setFormValues(this.groupSearchFormKey, { search, role });
       return groups.filter((group) => this.searchFilter(search, group)).filter((group) => this.roleFilter(role, group));
     })
   );
@@ -71,11 +86,11 @@ export class GroupsComponent {
   }
 
   get rolesFormControl() {
-    return this.form.get('roles') as FormControl;
+    return this.form.get('role') as FormControl;
   }
 
   private roleFilter(role: string, group: SecurityGroup): boolean {
-    return role.length ? role === group.role?.name : true;
+    return role ? role === group.role?.name : true;
   }
 
   private searchFilter(search: string, group: SecurityGroup): boolean {

--- a/src/app/admin/components/users/user-search-form/user-search-form.component.spec.ts
+++ b/src/app/admin/components/users/user-search-form/user-search-form.component.spec.ts
@@ -12,6 +12,7 @@ describe('UserSearchFormComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(UserSearchFormComponent);
+    fixture.componentRef.setInput('formValues', { fullName: null, email: null, userStatus: 'active' });
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -46,7 +47,7 @@ describe('UserSearchFormComponent', () => {
     expect(component.clear.emit).toHaveBeenCalled();
   });
 
-  it('should generate error if over 26 characters', () => {
+  it('should generate error if over 256 characters', () => {
     // Generate string that is over 256 characters
     // 257 "a" characters will do
     const characters = 257;

--- a/src/app/admin/components/users/user-search-form/user-search-form.component.ts
+++ b/src/app/admin/components/users/user-search-form/user-search-form.component.ts
@@ -1,7 +1,6 @@
 import { UserSearchFormValues } from '@admin-types/users/user-search-form-values.type';
-import { JsonPipe, NgClass } from '@angular/common';
-import { Component, EventEmitter, Output, inject } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { Component, EventEmitter, Output, inject, input } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormErrorMessages } from '@core-types/index';
 import { optionalMaxLengthValidator } from '@validators/optional-maxlength.validator';
 
@@ -16,23 +15,26 @@ const controlErrors: FormErrorMessages = {
 @Component({
   selector: 'app-user-search-form',
   standalone: true,
-  imports: [ReactiveFormsModule, JsonPipe, NgClass],
+  imports: [ReactiveFormsModule],
   templateUrl: './user-search-form.component.html',
   styleUrl: './user-search-form.component.scss',
 })
 export class UserSearchFormComponent {
+  formValues = input.required<UserSearchFormValues>();
+
   @Output() submitForm = new EventEmitter<UserSearchFormValues>();
   @Output() clear = new EventEmitter<void>();
 
-  formDefaultValues: UserSearchFormValues = { fullName: null, email: null, userStatus: 'active' };
-
   fb = inject(FormBuilder);
+  form!: FormGroup;
 
-  form = this.fb.group({
-    fullName: [this.formDefaultValues.fullName, [optionalMaxLengthValidator(256)]],
-    email: [this.formDefaultValues.email, [optionalMaxLengthValidator(256)]],
-    userStatus: this.formDefaultValues.userStatus,
-  });
+  ngOnInit() {
+    this.form = this.fb.group({
+      fullName: [this.formValues().fullName, [optionalMaxLengthValidator(256)]],
+      email: [this.formValues().email, [optionalMaxLengthValidator(256)]],
+      userStatus: this.formValues().userStatus,
+    });
+  }
 
   onSubmit() {
     if (this.form.valid) {
@@ -41,7 +43,7 @@ export class UserSearchFormComponent {
   }
 
   clearSearch() {
-    this.form.reset(this.formDefaultValues);
+    this.form.reset({ email: null, fullName: null, userStatus: 'active' });
     this.clear.emit();
   }
 

--- a/src/app/admin/components/users/user-search-form/user-search-form.component.ts
+++ b/src/app/admin/components/users/user-search-form/user-search-form.component.ts
@@ -1,5 +1,5 @@
 import { UserSearchFormValues } from '@admin-types/users/user-search-form-values.type';
-import { Component, EventEmitter, Output, inject, input } from '@angular/core';
+import { Component, EventEmitter, Output, inject, input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormErrorMessages } from '@core-types/index';
 import { optionalMaxLengthValidator } from '@validators/optional-maxlength.validator';
@@ -19,7 +19,7 @@ const controlErrors: FormErrorMessages = {
   templateUrl: './user-search-form.component.html',
   styleUrl: './user-search-form.component.scss',
 })
-export class UserSearchFormComponent {
+export class UserSearchFormComponent implements OnInit {
   formValues = input.required<UserSearchFormValues>();
 
   @Output() submitForm = new EventEmitter<UserSearchFormValues>();

--- a/src/app/admin/components/users/user-search-results/user-search-results.component.ts
+++ b/src/app/admin/components/users/user-search-results/user-search-results.component.ts
@@ -1,5 +1,4 @@
 import { User } from '@admin-types/index';
-import { NgClass } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
@@ -10,7 +9,7 @@ import { TableRowTemplateDirective } from '@directives/table-row-template.direct
 @Component({
   selector: 'app-user-search-results',
   standalone: true,
-  imports: [DataTableComponent, TableRowTemplateDirective, NgClass, RouterLink, GovukTagComponent],
+  imports: [DataTableComponent, TableRowTemplateDirective, RouterLink, GovukTagComponent],
   templateUrl: './user-search-results.component.html',
   styleUrl: './user-search-results.component.scss',
 })

--- a/src/app/admin/components/users/users.component.html
+++ b/src/app/admin/components/users/users.component.html
@@ -9,7 +9,7 @@
 </div>
 <app-govuk-heading tag="h2" size="m">Search for user</app-govuk-heading>
 
-<app-user-search-form (submitForm)="onSubmit($event)" (clear)="onClear()" />
+<app-user-search-form [formValues]="formValues()" (submitForm)="onSubmit($event)" (clear)="onClear()" />
 
 @if (loading$ | async) {
   <app-loading />

--- a/src/app/admin/components/users/users.component.spec.ts
+++ b/src/app/admin/components/users/users.component.spec.ts
@@ -46,7 +46,6 @@ describe('UsersComponent', () => {
   it('should call searchUsers when search is triggered', () => {
     jest.spyOn(userAdminService, 'searchUsers').mockReturnValue(of([]));
     component.search$.next({}); // Trigger search
-    component.isSubmitted$.next(true);
     expect(userAdminService.searchUsers).toHaveBeenCalled();
   });
 
@@ -54,7 +53,6 @@ describe('UsersComponent', () => {
     const searchValues = { fullName: 'test', email: 'admin', active: true };
     jest.spyOn(userAdminService, 'searchUsers').mockReturnValue(of([]));
     component.search$.next(searchValues); // Trigger search
-    component.isSubmitted$.next(true);
     fixture.detectChanges();
     expect(userAdminService.searchUsers).toHaveBeenCalledWith(searchValues);
   });
@@ -63,15 +61,5 @@ describe('UsersComponent', () => {
     jest.spyOn(component.search$, 'next');
     component.onClear();
     expect(component.search$.next).toHaveBeenCalledWith(null);
-  });
-
-  it('should set isSubmitted to true when onSubmit is called', () => {
-    component.onSubmit({}); // Trigger submit
-    expect(component.isSubmitted$.value).toBe(true);
-  });
-
-  it('should set isSubmitted to false when onClear is called', () => {
-    component.onClear();
-    expect(component.isSubmitted$.value).toBe(false);
   });
 });

--- a/src/app/admin/components/users/users.component.ts
+++ b/src/app/admin/components/users/users.component.ts
@@ -1,12 +1,12 @@
 import { UserSearchFormValues } from '@admin-types/users/user-search-form-values.type';
-import { AsyncPipe, JsonPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '@common/loading/loading.component';
+import { FormStateService } from '@services/form-state.service';
 import { UserAdminService } from '@services/user-admin/user-admin.service';
 import { UserService } from '@services/user/user.service';
-import { BehaviorSubject, combineLatest } from 'rxjs';
 import { Subject } from 'rxjs/internal/Subject';
 import { of } from 'rxjs/internal/observable/of';
 import { switchMap } from 'rxjs/internal/operators/switchMap';
@@ -14,39 +14,45 @@ import { tap } from 'rxjs/internal/operators/tap';
 import { UserSearchFormComponent } from './user-search-form/user-search-form.component';
 import { UserSearchResultsComponent } from './user-search-results/user-search-results.component';
 
+const defaultFormValues: UserSearchFormValues = {
+  fullName: null,
+  email: null,
+  userStatus: 'active',
+};
+
 @Component({
   selector: 'app-users',
   standalone: true,
-  imports: [
-    GovukHeadingComponent,
-    UserSearchFormComponent,
-    UserSearchResultsComponent,
-    AsyncPipe,
-    JsonPipe,
-    LoadingComponent,
-  ],
+  imports: [GovukHeadingComponent, UserSearchFormComponent, UserSearchResultsComponent, AsyncPipe, LoadingComponent],
   templateUrl: './users.component.html',
   styleUrl: './users.component.scss',
 })
 export class UsersComponent {
+  private readonly usersSearchKey = 'admin-user-search';
   userService = inject(UserService);
   userAdminService = inject(UserAdminService);
+  formStateService = inject(FormStateService);
+
+  previousformValues = signal(this.formStateService.getFormValues<UserSearchFormValues>(this.usersSearchKey));
+  formValues = computed(() => this.previousformValues() ?? defaultFormValues);
+
   router = inject(Router);
 
   search$ = new Subject<UserSearchFormValues | null>();
   loading$ = new Subject<boolean>();
-  isSubmitted$ = new BehaviorSubject<boolean>(false);
 
-  results$ = combineLatest([this.search$, this.isSubmitted$]).pipe(
+  results$ = this.search$.pipe(
     tap(() => this.startLoading()),
-    switchMap(([values, isSubmitted]) => {
-      if (!values || !isSubmitted) {
-        return of(null);
-      }
+    switchMap((values) => {
+      if (!values) return of(null);
       return this.userAdminService.searchUsers(values);
     }),
     tap(() => this.stopLoading())
   );
+
+  eff = effect(() => {
+    this.search$.next(this.previousformValues());
+  });
 
   startLoading() {
     this.loading$.next(true);
@@ -57,14 +63,12 @@ export class UsersComponent {
   }
 
   onSubmit(values: UserSearchFormValues) {
-    if (this.isSubmitted$.value === false) {
-      this.isSubmitted$.next(true);
-    }
+    this.formStateService.setFormValues(this.usersSearchKey, values);
     this.search$.next(values); // Trigger the search
   }
 
   onClear() {
-    this.isSubmitted$.next(false);
+    this.formStateService.clearFormValues(this.usersSearchKey);
     this.search$.next(null); // Clear the search
   }
 }

--- a/src/app/admin/components/users/users.component.ts
+++ b/src/app/admin/components/users/users.component.ts
@@ -50,9 +50,11 @@ export class UsersComponent {
     tap(() => this.stopLoading())
   );
 
-  eff = effect(() => {
-    this.search$.next(this.previousformValues());
-  });
+  constructor() {
+    effect(() => {
+      this.search$.next(this.previousformValues());
+    });
+  }
 
   startLoading() {
     this.loading$.next(true);

--- a/src/app/core/services/form-state.service.spec.ts
+++ b/src/app/core/services/form-state.service.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormStateService } from './form-state.service';
+
+describe('FormStateService', () => {
+  let service: FormStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FormStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should set and get form values', () => {
+    const screenId = 'testScreen';
+    const formValues = { field1: 'value1', field2: 'value2' };
+
+    service.setFormValues(screenId, formValues);
+    const result = service.getFormValues<typeof formValues>(screenId);
+
+    expect(result).toEqual(formValues);
+  });
+
+  it('should return null for non-existing form values', () => {
+    const result = service.getFormValues('nonExistingScreen');
+    expect(result).toBeNull();
+  });
+
+  it('should clear form values', () => {
+    const screenId = 'testScreen';
+    const formValues = { field1: 'value1', field2: 'value2' };
+
+    service.setFormValues(screenId, formValues);
+    service.clearFormValues(screenId);
+    const result = service.getFormValues<typeof formValues>(screenId);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/core/services/form-state.service.ts
+++ b/src/app/core/services/form-state.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, signal } from '@angular/core';
+/**
+ * Service to manage the state of forms within the application.
+ *
+ * @remarks
+ * This service provides methods to get, set, and clear form values
+ * for different screens identified by a screen ID.
+ *
+ * @example
+ * ```typescript
+ * formStateService = inject(FormStateService);
+ * formStateService.setFormValues('screen1', { name: 'John Doe' });
+ * const values = formStateService.getFormValues<{ name: string }>('screen1');
+ * console.log(values); // Output: { name: 'John Doe' }
+ * formStateService.clearFormValues('screen1');
+ * ```
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FormStateService {
+  private readonly state = signal<Record<string, unknown>>({});
+
+  getFormValues<T>(screenId: string): T | null {
+    return (this.state()[screenId] as T) ?? null;
+  }
+
+  setFormValues(screenId: string, formValues: unknown) {
+    this.state.update((forms) => ({
+      ...forms,
+      [screenId]: formValues,
+    }));
+  }
+
+  clearFormValues(screenId: string) {
+    this.state.update((forms) => {
+      const { [screenId]: _, ...rest } = forms;
+      return rest;
+    });
+  }
+}


### PR DESCRIPTION
### Jira link

[DMP-4209](https://tools.hmcts.net/jira/browse/DMP-4209)

### Change description

Added new FormStateService to support persistence of form values

Form values and results are now persisted when returning to a previously used search form on:
- http://localhost:3000/admin/users
- http://localhost:3000/admin/groups
- http://localhost:3000/admin/courthouses
