### PR TITLE
DMP-4217: Add confirmation screen when running an inactive automated task

### DIFF
--- a/cypress/e2e/functional/admin-portal/automated-tasks-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/automated-tasks-spec.cy.js
@@ -39,7 +39,7 @@ describe('Admin - Automated tasks screen', () => {
       cy.a11y();
     });
 
-    it('Not found', () => {
+    it('Task not found', () => {
       cy.get('app-data-table').contains('Task 2').parents('tr').contains('Run task').click();
       cy.get('app-automated-task-status').contains('Task not found: Task 2');
     });
@@ -48,13 +48,18 @@ describe('Admin - Automated tasks screen', () => {
       cy.get('app-data-table').contains('Task 3').parents('tr').contains('Run task').click();
       cy.get('app-automated-task-status').contains('Task is already running: Task 3');
     });
+
+    it('Inactive task', () => {
+      cy.get('app-data-table').contains('Task 4').parents('tr').contains('Run task').click();
+      cy.get('app-govuk-heading').contains('Are you sure you want to run the inactive task "Task 4"?');
+      cy.get('.govuk-button').contains('Yes').click();
+      cy.get('app-automated-task-status').contains('Task start request sent: Task 4');
+    });
   });
 
   describe('View task', () => {
-    beforeEach(() => {
-      cy.get('app-data-table').contains('Task 1').parents('tr').get('a').contains('1').click();
-    });
     it('page elements', () => {
+      cy.get('app-data-table').contains('Task 1').parents('tr').get('a').contains('1').click();
       cy.get('app-govuk-heading h1').contains('Task 1');
       cy.get('app-govuk-heading .caption').contains('Automated task');
       cy.get('.govuk-tag').contains('Active');
@@ -75,21 +80,32 @@ describe('Admin - Automated tasks screen', () => {
       cy.a11y();
     });
 
-    it('runs task', () => {
+    it('runs active task', () => {
+      cy.get('app-data-table').contains('Task 1').parents('tr').get('a').contains('1').click();
       cy.get('.govuk-button').contains('Run task').click();
       cy.get('app-automated-task-status').contains('Task start request sent: Task 1');
     });
 
     it('deactivates task', () => {
+      cy.get('app-data-table').contains('Task 1').parents('tr').get('a').contains('1').click();
       cy.get('.govuk-button').contains('Make inactive').click();
       cy.get('app-automated-task-status').contains('Task 1 is inactive: Task 1');
       cy.get('.govuk-tag.govuk-tag--grey').contains('Inactive');
     });
 
     it('activates task', () => {
+      cy.get('app-data-table').contains('Task 1').parents('tr').get('a').contains('1').click();
       cy.get('.govuk-button').contains('Make active').click();
       cy.get('app-automated-task-status').contains('Task 1 is active: Task 1');
       cy.get('.govuk-tag').contains('Active');
+    });
+
+    it('runs inactive task with confirmation screen', () => {
+      cy.get('app-data-table').contains('Task 4').parents('tr').get('a').contains('4').click();
+      cy.get('.govuk-button').contains('Run task').click();
+      cy.get('app-govuk-heading').contains('Are you sure you want to run the inactive task "Task 4"?');
+      cy.get('.govuk-button').contains('Yes').click();
+      cy.get('app-automated-task-status').contains('Task start request sent: Task 4');
     });
   });
 

--- a/darts-api-stub/admin/automated-tasks/automated-tasks.js
+++ b/darts-api-stub/admin/automated-tasks/automated-tasks.js
@@ -26,7 +26,7 @@ const defaultAutomatedTasks = [
     cron_expression: '0 0 2 * * *',
     is_cron_editable: true,
     batch_size: 500,
-    is_active: false,
+    is_active: true,
     created_at: '2024-01-02T00:00:00Z',
     created_by: 2,
     last_modified_at: '2024-01-02T00:00:00Z',
@@ -47,6 +47,19 @@ const defaultAutomatedTasks = [
     created_by: 3,
     last_modified_at: '2024-01-03T00:00:00Z',
     last_modified_by: 4,
+  },
+  {
+    id: 4,
+    name: 'Task 4',
+    description: 'Simulate running inactive task',
+    cron_expression: '0 0 4 * * *',
+    is_cron_editable: true,
+    batch_size: 100,
+    is_active: false,
+    created_at: '2024-01-04T00:00:00Z',
+    created_by: 4,
+    last_modified_at: '2024-01-04T00:00:00Z',
+    last_modified_by: 5,
   },
 ];
 
@@ -69,6 +82,8 @@ router.post('/:id/run', (req, res) => {
       return res.sendStatus(404);
     case '3':
       return res.sendStatus(409);
+    case '4':
+      return res.status(202).end();
     default:
       return res.sendStatus(404);
   }

--- a/src/app/admin/admin.routes.ts
+++ b/src/app/admin/admin.routes.ts
@@ -360,6 +360,15 @@ export const ADMIN_ROUTES: Routes = [
       ),
   },
   {
+    path: 'admin/system-configuration/automated-tasks/:id/run',
+    title: 'DARTS Admin Run Automated Task',
+    data: { allowedRoles: ['SUPER_ADMIN'] },
+    loadComponent: () =>
+      import('./components/automated-tasks/run-automated-task/run-automated-task.component').then(
+        (c) => c.RunAutomatedTaskComponent
+      ),
+  },
+  {
     path: 'admin/system-configuration/retention-policies/:id/create-revision',
     title: 'DARTS Admin New Version Retention Policy',
     data: { allowedRoles: ['SUPER_ADMIN'] },

--- a/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.html
+++ b/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.html
@@ -1,3 +1,3 @@
-@if (status()) {
+@if (latestTaskStatus()) {
   <app-govuk-banner [type]="banner()">{{ text() }}</app-govuk-banner>
 }

--- a/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.spec.ts
+++ b/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.spec.ts
@@ -1,72 +1,76 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { By } from '@angular/platform-browser';
-import { GovukBannerComponent } from '@common/govuk-banner/govuk-banner.component';
+import { AutomatedTaskStatus } from '@admin-types/automated-task/automated-task-status';
 import { AutomatedTaskStatusComponent } from './automated-task-status.component';
+
+const mockAutomatedTaskStatus: AutomatedTaskStatus = {
+  taskId: 1,
+  taskName: 'TestTask',
+  status: 'success',
+};
 
 describe('AutomatedTaskStatusComponent', () => {
   let component: AutomatedTaskStatusComponent;
   let fixture: ComponentFixture<AutomatedTaskStatusComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  const setup = (task: AutomatedTaskStatus) => {
+    TestBed.configureTestingModule({
       imports: [AutomatedTaskStatusComponent],
+      providers: [],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutomatedTaskStatusComponent);
+    fixture.componentRef.setInput('latestTaskStatus', task);
     component = fixture.componentInstance;
 
     fixture.detectChanges();
-  });
+  };
 
   it('should create', () => {
-    // no status set, banner should not be displayed
-    expect(fixture.debugElement.query(By.directive(GovukBannerComponent))).toBeFalsy();
+    setup(mockAutomatedTaskStatus);
     expect(component).toBeTruthy();
   });
 
   describe('text signal', () => {
-    it('should return "Task start request sent" when status is "success"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'success']);
+    it('return "Task start request sent" when status is "success"', () => {
+      setup(mockAutomatedTaskStatus);
       expect(component.text()).toBe('Task start request sent: TestTask');
     });
 
-    it('should return "Task not found" when status is "not-found"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'not-found']);
+    it('return "Task not found" when status is "not-found"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'not-found' });
       expect(component.text()).toBe('Task not found: TestTask');
     });
 
-    it('should return "Task is already running" when status is "already-running"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'already-running']);
+    it('return "Task is already running" when status is "already-running"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'already-running' });
       expect(component.text()).toBe('Task is already running: TestTask');
     });
 
-    it('should return "Task {taskId} is inactive" when status is "inactive"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'inactive']);
-      fixture.componentRef.setInput('taskId', 1);
+    it('return "Task {taskId} is inactive" when status is "inactive"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'inactive' });
       expect(component.text()).toBe('Task 1 is inactive: TestTask');
     });
 
-    it('should return "Task {taskId} is active" when status is "active"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'active']);
-      fixture.componentRef.setInput('taskId', 1);
+    it('return "Task {taskId} is active" when status is "active"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'active' });
       expect(component.text()).toBe('Task 1 is active: TestTask');
     });
   });
 
   describe('banner signal', () => {
-    it('should return "success" when status is not "not-found" or "already-running"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'success']);
+    it('return "success" when status is not "not-found" or "already-running"', () => {
+      setup(mockAutomatedTaskStatus);
       expect(component.banner()).toBe('success');
     });
 
-    it('should return "warning" when status is "not-found"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'not-found']);
+    it('return "warning" when status is "not-found"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'not-found' });
       expect(component.banner()).toBe('warning');
     });
 
-    it('should return "warning" when status is "already-running"', () => {
-      fixture.componentRef.setInput('status', ['TestTask', 'already-running']);
+    it('return "warning" when status is "already-running"', () => {
+      setup({ ...mockAutomatedTaskStatus, status: 'already-running' });
       expect(component.banner()).toBe('warning');
     });
   });

--- a/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.ts
+++ b/src/app/admin/components/automated-tasks/automated-task-status/automated-task-status.component.ts
@@ -10,13 +10,13 @@ import { GovukBannerComponent } from '@common/govuk-banner/govuk-banner.componen
   styleUrl: './automated-task-status.component.scss',
 })
 export class AutomatedTaskStatusComponent {
-  status = input<AutomatedTaskStatus | null>(null);
-  taskId = input<number | null>(null);
+  latestTaskStatus = input.required<AutomatedTaskStatus | null>();
 
   text = computed(() => {
-    const statusGroup = this.status();
-    const taskName = statusGroup ? statusGroup[0] : null;
-    const status = statusGroup ? statusGroup[1] : null;
+    const taskId = this.latestTaskStatus()?.taskId;
+    const taskName = this.latestTaskStatus()?.taskName;
+    const status = this.latestTaskStatus()?.status;
+
     switch (status) {
       case 'success':
         return `Task start request sent: ${taskName}`;
@@ -25,18 +25,17 @@ export class AutomatedTaskStatusComponent {
       case 'already-running':
         return `Task is already running: ${taskName}`;
       case 'inactive':
-        return `Task ${this.taskId()} is inactive: ${taskName}`;
+        return `Task ${taskId} is inactive: ${taskName}`;
       case 'active':
-        return `Task ${this.taskId()} is active: ${taskName}`;
+        return `Task ${taskId} is active: ${taskName}`;
       default:
         return '';
     }
   });
 
-  banner = computed(() => {
-    const statusGroup = this.status();
-    const status = statusGroup ? statusGroup[1] : null;
-    // const taskName = statusGroup ? statusGroup[0] : null;
-    return status === 'not-found' || status === 'already-running' ? 'warning' : 'success';
-  });
+  banner = computed(() =>
+    this.latestTaskStatus()?.status === 'not-found' || this.latestTaskStatus()?.status === 'already-running'
+      ? 'warning'
+      : 'success'
+  );
 }

--- a/src/app/admin/components/automated-tasks/automated-tasks.component.html
+++ b/src/app/admin/components/automated-tasks/automated-tasks.component.html
@@ -16,9 +16,7 @@
       <td>{{ row.cronExpression }}</td>
       <td>{{ row.isActive ? 'Active' : 'Inactive' }}</td>
       <td>
-        <button class="govuk-button govuk-button--secondary" (click)="onRunTaskButtonClicked(row.id, row.name)">
-          Run task
-        </button>
+        <button class="govuk-button govuk-button--secondary" (click)="onRunTaskButtonClicked(row)">Run task</button>
       </td>
     </ng-template>
   </app-data-table>

--- a/src/app/admin/components/automated-tasks/automated-tasks.component.spec.ts
+++ b/src/app/admin/components/automated-tasks/automated-tasks.component.spec.ts
@@ -1,13 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { HttpResponse } from '@angular/common/http';
+import { AutomatedTask } from '@admin-types/automated-task/automated-task';
+import { provideRouter, Router } from '@angular/router';
 import { AutomatedTasksService } from '@services/automated-tasks/automated-tasks.service';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { AutomatedTasksComponent } from './automated-tasks.component';
+
+const mockTask: AutomatedTask = {
+  id: 1,
+  name: 'TestTask',
+  description: 'Task 1 description',
+  cronExpression: '1 0 0 * * *',
+  isActive: true,
+};
 
 describe('AutomatedTasksComponent', () => {
   let component: AutomatedTasksComponent;
   let fixture: ComponentFixture<AutomatedTasksComponent>;
+  let routerNavigateSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,12 +25,19 @@ describe('AutomatedTasksComponent', () => {
       providers: [
         {
           provide: AutomatedTasksService,
-          useValue: { getTasks: jest.fn().mockReturnValue(of([])), runTask: jest.fn().mockReturnValue(of()) },
+          useValue: {
+            getTasks: jest.fn().mockReturnValue(of([])),
+            runTask: jest.fn().mockReturnValue(of()),
+            clearLatestTaskStatus: jest.fn(),
+          },
         },
+        provideRouter([]),
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AutomatedTasksComponent);
+    const router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -30,40 +47,36 @@ describe('AutomatedTasksComponent', () => {
   });
 
   describe('onRunTaskButtonClicked', () => {
-    it('emits "success" when the task is run successfully', () => {
-      const runTaskSpy = jest
-        .spyOn(component.automatedTasksService, 'runTask')
-        .mockReturnValue(of({} as unknown as HttpResponse<void>));
-      const taskRunSpy = jest.spyOn(component.taskRun, 'emit');
+    it('calls automatedTasksService.runTask if task is active', () => {
+      const runTaskSpy = jest.spyOn(component.automatedTasksService, 'runTask');
 
-      component.onRunTaskButtonClicked(1, 'TestTask');
+      component.onRunTaskButtonClicked(mockTask);
 
-      expect(runTaskSpy).toHaveBeenCalledWith(1);
-      expect(taskRunSpy).toHaveBeenCalledWith(['TestTask', 'success']);
+      expect(runTaskSpy).toHaveBeenCalledWith(mockTask);
     });
 
-    it('emits "not-found" when the task is not found', () => {
-      const runTaskSpy = jest
-        .spyOn(component.automatedTasksService, 'runTask')
-        .mockReturnValue(throwError(() => ({ status: 404 }) as unknown as HttpResponse<void>));
-      const taskRunSpy = jest.spyOn(component.taskRun, 'emit');
+    it('navigates to the confirmation page if task is not active', () => {
+      mockTask.isActive = false;
 
-      component.onRunTaskButtonClicked(2, 'TestTask');
+      component.onRunTaskButtonClicked(mockTask);
 
-      expect(runTaskSpy).toHaveBeenCalledWith(2);
-      expect(taskRunSpy).toHaveBeenCalledWith(['TestTask', 'not-found']);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(
+        ['admin/system-configuration/automated-tasks', mockTask.id, 'run'],
+        {
+          queryParams: { backUrl: component.router.url },
+          state: { task: mockTask },
+        }
+      );
     });
+  });
 
-    it('emits "already-running" when the task is already running', () => {
-      const runTaskSpy = jest
-        .spyOn(component.automatedTasksService, 'runTask')
-        .mockReturnValue(throwError(() => ({ status: 409 }) as unknown as HttpResponse<void>));
-      const taskRunSpy = jest.spyOn(component.taskRun, 'emit');
+  describe('onDestroy', () => {
+    it('calls clearLatestTaskStatus', () => {
+      const clearLatestTaskStatusSpy = jest.spyOn(component.automatedTasksService, 'clearLatestTaskStatus');
 
-      component.onRunTaskButtonClicked(3, 'TestTask');
+      component.ngOnDestroy();
 
-      expect(runTaskSpy).toHaveBeenCalledWith(3);
-      expect(taskRunSpy).toHaveBeenCalledWith(['TestTask', 'already-running']);
+      expect(clearLatestTaskStatusSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.html
+++ b/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.html
@@ -1,0 +1,10 @@
+@if (task) {
+  <app-govuk-heading class="two-thirds" style="display: block">
+    Are you sure you want to run the {{ task.isActive ? 'active' : 'inactive' }} task "{{ task.name }}"?
+  </app-govuk-heading>
+
+  <div class="govuk-button-group">
+    <button class="govuk-button govuk-button--warning" type="submit" (click)="onConfirm(task)">Yes - run task</button>
+    <a [routerLink]="[backUrl]" class="govuk-link">Cancel</a>
+  </div>
+}

--- a/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.html
+++ b/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.html
@@ -1,5 +1,5 @@
 @if (task) {
-  <app-govuk-heading class="two-thirds" style="display: block">
+  <app-govuk-heading size="xl" class="two-thirds" style="display: block">
     Are you sure you want to run the {{ task.isActive ? 'active' : 'inactive' }} task "{{ task.name }}"?
   </app-govuk-heading>
 

--- a/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.spec.ts
+++ b/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AutomatedTask } from '@admin-types/automated-task/automated-task';
+import { Navigation, provideRouter, Router } from '@angular/router';
+import { AutomatedTasksService } from '@services/automated-tasks/automated-tasks.service';
+import { HeaderService } from '@services/header/header.service';
+import { of } from 'rxjs';
+import { RunAutomatedTaskComponent } from './run-automated-task.component';
+
+const mockAutomatedTask: AutomatedTask = {
+  id: 0,
+  name: '',
+  description: '',
+  cronExpression: '',
+  isActive: false,
+};
+
+describe('RunAutomatedTaskComponent', () => {
+  let component: RunAutomatedTaskComponent;
+  let fixture: ComponentFixture<RunAutomatedTaskComponent>;
+  let routerNavigateSpy: jest.SpyInstance;
+  let hideNavigationSpy: jest.SpyInstance;
+
+  const setup = (task?: AutomatedTask) => {
+    TestBed.configureTestingModule({
+      imports: [RunAutomatedTaskComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AutomatedTasksService,
+          useValue: {
+            runTask: jest.fn().mockReturnValue(of({})),
+            clearLatestTaskStatus: jest.fn(),
+          },
+        },
+      ],
+    });
+
+    const router = TestBed.inject(Router);
+    const headerService = TestBed.inject(HeaderService);
+
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
+    hideNavigationSpy = jest.spyOn(headerService, 'hideNavigation');
+    jest.spyOn(router, 'getCurrentNavigation').mockReturnValue({
+      extras: { state: { task } },
+    } as unknown as Navigation);
+
+    fixture = TestBed.createComponent(RunAutomatedTaskComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  describe('when task is not provided', () => {
+    it('should create', () => {
+      setup();
+      expect(component.task).toBeUndefined();
+      expect(component).toBeTruthy();
+    });
+
+    it('should redirect to the previous page', () => {
+      setup();
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['/admin/system-configuration/automated-tasks']);
+    });
+  });
+
+  describe('when task is provided', () => {
+    beforeEach(() => {
+      setup(mockAutomatedTask);
+    });
+
+    it('should create', () => {
+      expect(component.task).toEqual(mockAutomatedTask);
+      expect(component).toBeTruthy();
+    });
+
+    it('hides the navigation', () => {
+      fixture.detectChanges();
+      expect(hideNavigationSpy).toHaveBeenCalled();
+    });
+
+    it('run the task on confirmation', () => {
+      component.onConfirm(mockAutomatedTask);
+      expect(component.automatedTasksService.runTask).toHaveBeenCalledWith(mockAutomatedTask);
+    });
+
+    it('navigate back after running the task', () => {
+      component.onConfirm(mockAutomatedTask);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['/admin/system-configuration/automated-tasks']);
+    });
+  });
+});

--- a/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.ts
+++ b/src/app/admin/components/automated-tasks/run-automated-task/run-automated-task.component.ts
@@ -1,0 +1,47 @@
+import { AutomatedTask } from '@admin-types/automated-task/automated-task';
+import { Component, inject, OnInit } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
+import { AutomatedTasksService } from '@services/automated-tasks/automated-tasks.service';
+import { HeaderService } from '@services/header/header.service';
+import { HistoryService } from '@services/history/history.service';
+import { finalize } from 'rxjs';
+
+@Component({
+  selector: 'app-run-automated-task',
+  standalone: true,
+  imports: [GovukHeadingComponent, RouterLink],
+  templateUrl: './run-automated-task.component.html',
+  styleUrl: './run-automated-task.component.scss',
+})
+export class RunAutomatedTaskComponent implements OnInit {
+  router = inject(Router);
+  historyService = inject(HistoryService);
+  automatedTasksService = inject(AutomatedTasksService);
+  headerService = inject(HeaderService);
+
+  task?: AutomatedTask = this.router.getCurrentNavigation()?.extras?.state?.task;
+  backUrl = this.historyService.getBackUrl(this.router.url) ?? '/admin/system-configuration/automated-tasks';
+
+  constructor() {
+    if (!this.task) {
+      this.router.navigate([this.backUrl]);
+      return;
+    }
+  }
+
+  ngOnInit(): void {
+    this.headerService.hideNavigation();
+  }
+
+  onConfirm(task: AutomatedTask) {
+    this.automatedTasksService
+      .runTask(task)
+      .pipe(
+        finalize(() => {
+          this.router.navigate([this.backUrl]);
+        })
+      )
+      .subscribe();
+  }
+}

--- a/src/app/admin/components/automated-tasks/view-automated-tasks/view-automated-tasks.component.html
+++ b/src/app/admin/components/automated-tasks/view-automated-tasks/view-automated-tasks.component.html
@@ -1,6 +1,6 @@
 <a [routerLink]="['../']" class="govuk-back-link">Back</a>
 
-<app-automated-task-status [taskId]="taskId" [status]="taskRunStatus()" />
+<app-automated-task-status [latestTaskStatus]="taskStatus()" />
 
 @if (batchSizeChanged()) {
   <app-govuk-banner type="success"> Batch size successfully updated </app-govuk-banner>
@@ -14,8 +14,8 @@
   <header>
     <app-govuk-heading size="xl" caption="Automated task">{{ task.name }}</app-govuk-heading>
     <div class="govuk-button-group">
-      <button class="govuk-button govuk-button--secondary" (click)="onRunTaskButtonClicked(task.name)">Run task</button>
-      <button class="govuk-button govuk-button--secondary" (click)="onActivateDeactiveButtonClicked(task.name)">
+      <button class="govuk-button govuk-button--secondary" (click)="onRunTaskButtonClicked(task)">Run task</button>
+      <button class="govuk-button govuk-button--secondary" (click)="onActivateDeactiveButtonClicked()">
         Make {{ task.isActive ? 'inactive' : 'active' }}
       </button>
     </div>

--- a/src/app/admin/components/system-configuration/system-configuration.component.html
+++ b/src/app/admin/components/system-configuration/system-configuration.component.html
@@ -20,7 +20,7 @@
   <app-govuk-banner type="information">Event mapping deleted</app-govuk-banner>
 }
 
-<app-automated-task-status [status]="taskStatus" />
+<app-automated-task-status [latestTaskStatus]="taskStatus()" />
 
 <app-govuk-heading tag="h1" size="xl">System configuration</app-govuk-heading>
 
@@ -29,5 +29,5 @@
 
   <app-event-mapping *tab="'Event mappings'" />
 
-  <app-automated-tasks *tab="'Automated tasks'" (taskRun)="taskStatus = $event" />
+  <app-automated-tasks *tab="'Automated tasks'" />
 </app-tabs>

--- a/src/app/admin/components/system-configuration/system-configuration.component.spec.ts
+++ b/src/app/admin/components/system-configuration/system-configuration.component.spec.ts
@@ -1,6 +1,8 @@
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TabDirective } from '@directives/tab.directive';
+import { AutomatedTasksService } from '@services/automated-tasks/automated-tasks.service';
 import { RetentionPoliciesService } from '@services/retention-policies/retention-policies.service';
 import { of } from 'rxjs';
 import { AutomatedTaskStatusComponent } from '../automated-tasks/automated-task-status/automated-task-status.component';
@@ -22,6 +24,10 @@ describe('SystemConfigurationComponent', () => {
           },
         },
         { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
+        {
+          provide: AutomatedTasksService,
+          useValue: { getLatestTaskStatus: jest.fn().mockReturnValue(signal(null)) },
+        },
       ],
     }).compileComponents();
 

--- a/src/app/admin/components/system-configuration/system-configuration.component.ts
+++ b/src/app/admin/components/system-configuration/system-configuration.component.ts
@@ -1,4 +1,3 @@
-import { AutomatedTaskStatus } from '@admin-types/automated-task/automated-task-status';
 import { AsyncPipe, Location } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -6,6 +5,7 @@ import { GovukBannerComponent } from '@common/govuk-banner/govuk-banner.componen
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { TabDirective } from '@directives/tab.directive';
+import { AutomatedTasksService } from '@services/automated-tasks/automated-tasks.service';
 import { map } from 'rxjs';
 import { AutomatedTaskStatusComponent } from '../automated-tasks/automated-task-status/automated-task-status.component';
 import { AutomatedTasksComponent } from '../automated-tasks/automated-tasks.component';
@@ -39,6 +39,8 @@ export class SystemConfigurationComponent {
   route = inject(ActivatedRoute);
   location = inject(Location);
 
+  taskStatus = inject(AutomatedTasksService).getLatestTaskStatus();
+
   hasEventMappingCreated$ = this.route.queryParams.pipe(map((params) => !!params.newEventMapping));
   hasEventMappingUpdated$ = this.route.queryParams.pipe(map((params) => !!params.isRevision));
   hasEventMappingDeleted$ = this.route.queryParams.pipe(map((params) => !!params.deleteEventMapping));
@@ -46,7 +48,6 @@ export class SystemConfigurationComponent {
   hasPolicyCreated$ = this.route.queryParams.pipe(map((params) => !!params.created));
   hasPolicyUpdated$ = this.route.queryParams.pipe(map((params) => !!params.updated));
   hasPolicyRevised$ = this.route.queryParams.pipe(map((params) => !!params.revised));
-  taskStatus: AutomatedTaskStatus | null = null;
 
   currentTab = this.getTabFromUrl(this.router.url);
 

--- a/src/app/admin/models/automated-task/automated-task-status.ts
+++ b/src/app/admin/models/automated-task/automated-task-status.ts
@@ -1,4 +1,5 @@
-export type AutomatedTaskStatus = [
-  taskName: string,
-  'success' | 'not-found' | 'already-running' | 'inactive' | 'active',
-];
+export type AutomatedTaskStatus = {
+  taskId: number;
+  taskName: string;
+  status: 'success' | 'not-found' | 'already-running' | 'inactive' | 'active';
+};


### PR DESCRIPTION
### Jira link

[DMP-4217](https://tools.hmcts.net/jira/browse/DMP-4217)

### Change description

Attempting to manually run an automated task presents user with a confirmation screen before sending the request on the following screens:

[/admin/system-configuration/automated-tasks](http://localhost:3000/admin/system-configuration/automated-tasks)
[/admin/system-configuration/automated-tasks/4](http://localhost:3000/admin/system-configuration/automated-tasks/4)

When the request completes the user is returned to where they came from.

<img width="1340" alt="image" src="https://github.com/user-attachments/assets/30377357-334c-4ba0-8aa5-beb4a2301397">

<img width="1336" alt="image" src="https://github.com/user-attachments/assets/3a7eda4d-add2-41eb-addb-9a1b07a9ec20">

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/88ba97e9-8ed8-4575-b280-b4c45c96d32f">

