### PR TITLE
DMP-4240 Add 'Is current?' property to audio file details screen

### DIFF
--- a/cypress/e2e/functional/admin-portal/audio-file-details-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/audio-file-details-spec.cy.js
@@ -58,6 +58,7 @@ describe('Admin - Audio file details screen', () => {
       cy.get('dt').contains('Hidden by').next('dd').should('contain', 'Trina Gulliver');
       cy.get('dt').contains('Date hidden').next('dd').should('contain', '11 Jun 2024 at 8:55:18AM');
       cy.get('dt').contains('Audio deleted?').next('dd').should('contain', 'Yes');
+      cy.get('dt').contains('Is current?').next('dd').should('contain', 'Yes');
       cy.get('dt').contains('Date deleted').next('dd').should('contain', '11 Jun 2024 at 8:55:18AM');
       cy.get('dt').contains('Deleted by').next('dd').should('contain', 'Michael van Gerwen');
 

--- a/darts-api-stub/admin/medias/medias.js
+++ b/darts-api-stub/admin/medias/medias.js
@@ -287,6 +287,7 @@ const defaultMedia = {
   media_status: 'media status',
   is_hidden: true,
   is_deleted: true,
+  is_current: true,
   admin_action: {
     id: 0,
     reason_id: 2,

--- a/src/app/admin/components/audio-file/advanced-audio-file-details/advanced-audio-file-details.component.html
+++ b/src/app/admin/components/audio-file/advanced-audio-file-details/advanced-audio-file-details.component.html
@@ -31,6 +31,14 @@
         {{ audioFile.mediaStatus }}
       </dd>
     </div>
+    @if (audioFile.isCurrent) {
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Is current?</dt>
+        <dd class="govuk-summary-list__value">
+          {{ audioFile.isCurrent ? 'Yes' : 'No' }}
+        </dd>
+      </div>
+    }
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Audio hidden?</dt>
       <dd class="govuk-summary-list__value">
@@ -61,14 +69,6 @@
         {{ audioFile.isDeleted ? 'Yes' : 'No' }}
       </dd>
     </div>
-    @if (audioFile.isCurrent) {
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Is current?</dt>
-        <dd class="govuk-summary-list__value">
-          {{ audioFile.isCurrent ? 'Yes' : 'No' }}
-        </dd>
-      </div>
-    }
     @if (audioFile.adminAction) {
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Date deleted</dt>

--- a/src/app/admin/components/audio-file/advanced-audio-file-details/advanced-audio-file-details.component.html
+++ b/src/app/admin/components/audio-file/advanced-audio-file-details/advanced-audio-file-details.component.html
@@ -61,6 +61,14 @@
         {{ audioFile.isDeleted ? 'Yes' : 'No' }}
       </dd>
     </div>
+    @if (audioFile.isCurrent) {
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Is current?</dt>
+        <dd class="govuk-summary-list__value">
+          {{ audioFile.isCurrent ? 'Yes' : 'No' }}
+        </dd>
+      </div>
+    }
     @if (audioFile.adminAction) {
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Date deleted</dt>

--- a/src/app/admin/models/transformed-media/audio-file-data.interface.ts
+++ b/src/app/admin/models/transformed-media/audio-file-data.interface.ts
@@ -17,6 +17,7 @@ export interface AudioFileData {
   media_status: string;
   is_hidden: boolean;
   is_deleted: boolean;
+  is_current?: boolean;
   admin_action: AdminActionData;
   version: string;
   chronicle_id: string;

--- a/src/app/admin/models/transformed-media/audio-file.ts
+++ b/src/app/admin/models/transformed-media/audio-file.ts
@@ -18,6 +18,7 @@ export type AudioFile = {
   mediaStatus: string;
   isHidden: boolean;
   isDeleted: boolean;
+  isCurrent?: boolean;
   adminAction?: AdminAction | null;
   version: string;
   chronicleId: string;

--- a/src/app/admin/services/transformed-media/transformed-media.service.ts
+++ b/src/app/admin/services/transformed-media/transformed-media.service.ts
@@ -274,6 +274,7 @@ export class TransformedMediaService {
       mediaStatus: data.media_status,
       isHidden: data.is_hidden,
       isDeleted: data.is_deleted,
+      isCurrent: data.is_current,
       adminAction: !data.admin_action
         ? undefined
         : {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DMP-4240

### Change description

Can be safely merged before [DMP-4270](https://tools.hmcts.net/jira/browse/DMP-4270) (backend counterpart change) is implemented. If the property isn't in the response then it won't render anything.

<img width="894" alt="image" src="https://github.com/user-attachments/assets/88f652f3-ee28-405e-b5fd-3f0c7232d3b4">
