### PR TITLE
DMP-4261 Expire user session gracefully

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,7 @@
   },
   "session": {
     "prefix": "darts-portal-session",
-    "ttlInSeconds": 28800
+    "ttlInSeconds": 28800,
     "cookieName": "darts_session",
     "overriddenNotSecretRedisConnectionString": null
   },

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,7 @@
   },
   "session": {
     "prefix": "darts-portal-session",
-    "ttlInSeconds": 30, // 30 seconds to be reverted after testing
+    "ttlInSeconds": 28800
     "cookieName": "darts_session",
     "overriddenNotSecretRedisConnectionString": null
   },

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,7 @@
   },
   "session": {
     "prefix": "darts-portal-session",
-    "ttlInSeconds": 28800,
+    "ttlInSeconds": 5,
     "cookieName": "darts_session",
     "overriddenNotSecretRedisConnectionString": null
   },

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,7 @@
   },
   "session": {
     "prefix": "darts-portal-session",
-    "ttlInSeconds": 5,
+    "ttlInSeconds": 30, // 30 seconds to be reverted after testing
     "cookieName": "darts_session",
     "overriddenNotSecretRedisConnectionString": null
   },

--- a/src/app/core/interceptors/error/error.interceptor.ts
+++ b/src/app/core/interceptors/error/error.interceptor.ts
@@ -17,8 +17,9 @@ export class ErrorInterceptor implements HttpInterceptor {
         if (error.status === 401) {
           console.log('Unauthorized access error: redirecting to login');
           this.window.location.href = '/login';
+        } else {
+          this.errorMessageService.handleErrorMessage(error);
         }
-        this.errorMessageService.handleErrorMessage(error);
         this.errorHandlerService.handleError(error);
         return throwError(() => error);
       })


### PR DESCRIPTION
### Jira link

[DMP-4261](https://tools.hmcts.net/jira/browse/DMP-4261)

Fix brief redirection to 'There is a problem with this service' screen and go directly to the login screen upon session expiry.

Session ttl reduced to 5 seconds to allow testing, must be reverted to 8 hours before merging
