### PR TITLE
DMP-4964 Clear saved tab when clicking into hearing details

### DIFF
--- a/cypress/e2e/functional/admin-portal/case-file-spec.cy.js
+++ b/cypress/e2e/functional/admin-portal/case-file-spec.cy.js
@@ -177,8 +177,7 @@ describe('Case file screen', () => {
             .click();
         });
 
-      // TO DO: Uncomment once admin hearing file is in
-      // cy.url().should('include', '/admin/case/1/hearing/1');
+      cy.url().should('include', '/admin/case/1/hearing/1');
     });
   });
 });

--- a/src/app/core/services/active-tab/active-tab.service.spec.ts
+++ b/src/app/core/services/active-tab/active-tab.service.spec.ts
@@ -17,4 +17,32 @@ describe('ActiveTabService', () => {
       expect(service.activeTabs()).toEqual({ testScreenId: 'testTabName' });
     });
   });
+
+  describe('clearActiveTab', () => {
+    it('should remove the tab for the given screenId', () => {
+      service.setActiveTab('screen1', 'tab1');
+      service.setActiveTab('screen2', 'tab2');
+
+      expect(service.activeTabs()).toEqual({
+        screen1: 'tab1',
+        screen2: 'tab2',
+      });
+
+      service.clearActiveTab('screen1');
+
+      expect(service.activeTabs()).toEqual({
+        screen2: 'tab2',
+      });
+    });
+
+    it('should do nothing if screenId does not exist', () => {
+      service.setActiveTab('screen1', 'tab1');
+
+      service.clearActiveTab('nonExistent');
+
+      expect(service.activeTabs()).toEqual({
+        screen1: 'tab1',
+      });
+    });
+  });
 });

--- a/src/app/core/services/active-tab/active-tab.service.ts
+++ b/src/app/core/services/active-tab/active-tab.service.ts
@@ -20,4 +20,11 @@ export class ActiveTabService {
       [screenId]: tabName,
     }));
   }
+
+  clearActiveTab(screenId: string) {
+    this.state.update((tabs) => {
+      const { [screenId]: _, ...rest } = tabs;
+      return rest;
+    });
+  }
 }

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.html
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.html
@@ -1,3 +1,6 @@
+@let isAdmin = adminScreen();
+@let id = caseId();
+
 <app-data-table
   id="hearingsTable"
   [rows]="hearings()"
@@ -7,7 +10,14 @@
 >
   <ng-template [tableRowTemplate]="hearings()" let-row>
     <td>
-      <a class="govuk-link" (click)="goToHearingDetails(row.id)"> {{ row.date | luxonDate: 'dd MMM y' }}</a>
+      <a
+        class="govuk-link"
+        (click)="clearStoredTabs()"
+        [routerLink]="[isAdmin ? '/admin/case' : '/case', id, 'hearing', row.id]"
+        [queryParams]="{ backUrl: '/admin/case/' + id }"
+      >
+        {{ row.date | luxonDate: 'dd MMM y' }}</a
+      >
     </td>
     <td>{{ row.judges }}</td>
     <td>{{ row.courtroom }}</td>

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.html
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.html
@@ -1,6 +1,3 @@
-@let isAdmin = adminScreen();
-@let id = caseId();
-
 <app-data-table
   id="hearingsTable"
   [rows]="hearings()"
@@ -10,13 +7,7 @@
 >
   <ng-template [tableRowTemplate]="hearings()" let-row>
     <td>
-      <a
-        class="govuk-link"
-        [routerLink]="[isAdmin ? '/admin/case' : '/case', id, 'hearing', row.id]"
-        [queryParams]="{ backUrl: '/admin/case/' + id }"
-      >
-        {{ row.date | luxonDate: 'dd MMM y' }}</a
-      >
+      <a class="govuk-link" (click)="goToHearingDetails(row.id)"> {{ row.date | luxonDate: 'dd MMM y' }}</a>
     </td>
     <td>{{ row.judges }}</td>
     <td>{{ row.courtroom }}</td>

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.spec.ts
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.spec.ts
@@ -1,22 +1,66 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Router } from '@angular/router';
+import { ActiveTabService } from '@services/active-tab/active-tab.service';
 import { CaseHearingsTableComponent } from './case-hearings-table.component';
 
 describe('CaseHearingsTableComponent', () => {
   let component: CaseHearingsTableComponent;
   let fixture: ComponentFixture<CaseHearingsTableComponent>;
+  let routerSpy: jest.Mocked<Router>;
+  let activeTabServiceSpy: jest.Mocked<ActiveTabService>;
 
   beforeEach(async () => {
+    routerSpy = {
+      navigate: jest.fn(),
+    } as unknown as jest.Mocked<Router>;
+
+    activeTabServiceSpy = {
+      clearActiveTab: jest.fn(),
+    } as unknown as jest.Mocked<ActiveTabService>;
+
     await TestBed.configureTestingModule({
       imports: [CaseHearingsTableComponent],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: ActiveTabService, useValue: activeTabServiceSpy },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CaseHearingsTableComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('goToHearingDetails', () => {
+    it('should navigate to admin path and clear admin tab when adminScreen is true', () => {
+      fixture.componentRef.setInput('caseId', 123);
+      fixture.componentRef.setInput('adminScreen', true);
+
+      fixture.detectChanges();
+
+      component.goToHearingDetails(456);
+
+      expect(activeTabServiceSpy.clearActiveTab).toHaveBeenCalledWith('admin-hearing-details');
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/admin/case', 123, 'hearing', 456], {
+        queryParams: { backUrl: '/admin/case/123' },
+      });
+    });
+
+    it('should navigate to user path and clear user tab when adminScreen is false', () => {
+      fixture.componentRef.setInput('caseId', 789);
+      fixture.componentRef.setInput('adminScreen', false);
+
+      fixture.detectChanges();
+
+      component.goToHearingDetails(987);
+
+      expect(activeTabServiceSpy.clearActiveTab).toHaveBeenCalledWith('hearing-screen');
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/case', 789, 'hearing', 987], {
+        queryParams: { backUrl: '/case/789' },
+      });
+    });
   });
 });

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.spec.ts
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.spec.ts
@@ -34,33 +34,27 @@ describe('CaseHearingsTableComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('goToHearingDetails', () => {
-    it('should navigate to admin path and clear admin tab when adminScreen is true', () => {
+  describe('clearStoredTabs', () => {
+    it('should clear admin tab when adminScreen is true', () => {
       fixture.componentRef.setInput('caseId', 123);
       fixture.componentRef.setInput('adminScreen', true);
 
       fixture.detectChanges();
 
-      component.goToHearingDetails(456);
+      component.clearStoredTabs();
 
       expect(activeTabServiceSpy.clearActiveTab).toHaveBeenCalledWith('admin-hearing-details');
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/admin/case', 123, 'hearing', 456], {
-        queryParams: { backUrl: '/admin/case/123' },
-      });
     });
 
-    it('should navigate to user path and clear user tab when adminScreen is false', () => {
+    it('should clear user tab when adminScreen is false', () => {
       fixture.componentRef.setInput('caseId', 789);
       fixture.componentRef.setInput('adminScreen', false);
 
       fixture.detectChanges();
 
-      component.goToHearingDetails(987);
+      component.clearStoredTabs();
 
       expect(activeTabServiceSpy.clearActiveTab).toHaveBeenCalledWith('hearing-screen');
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/case', 789, 'hearing', 987], {
-        queryParams: { backUrl: '/case/789' },
-      });
     });
   });
 });

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.ts
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, input } from '@angular/core';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { DatatableColumn } from '@core-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
@@ -10,12 +10,11 @@ import { ActiveTabService } from '@services/active-tab/active-tab.service';
 @Component({
   selector: 'app-case-hearings-table',
   standalone: true,
-  imports: [DataTableComponent, TableRowTemplateDirective, LuxonDatePipe],
+  imports: [DataTableComponent, TableRowTemplateDirective, LuxonDatePipe, RouterLink],
   templateUrl: './case-hearings-table.component.html',
   styleUrl: './case-hearings-table.component.scss',
 })
 export class CaseHearingsTableComponent {
-  router = inject(Router);
   activeTabService = inject(ActiveTabService);
 
   hearings = input<Hearing[]>([]);
@@ -29,14 +28,9 @@ export class CaseHearingsTableComponent {
     { name: 'No. of transcripts', prop: 'transcriptCount', sortable: true },
   ];
 
-  goToHearingDetails(hearingId: number): void {
+  clearStoredTabs(): void {
+    //Required to ensure other hearings don't use other active tabs
     const screenId = this.adminScreen() ? 'admin-hearing-details' : 'hearing-screen';
     this.activeTabService.clearActiveTab(screenId);
-
-    const basePath = this.adminScreen() ? '/admin/case' : '/case';
-
-    this.router.navigate([basePath, this.caseId(), 'hearing', hearingId], {
-      queryParams: { backUrl: `${basePath}/${this.caseId()}` },
-    });
   }
 }

--- a/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.ts
+++ b/src/app/portal/components/case/case-file/case-hearings-table/case-hearings-table.component.ts
@@ -1,19 +1,23 @@
-import { Component, input } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, inject, input } from '@angular/core';
+import { Router } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { DatatableColumn } from '@core-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import { Hearing } from '@portal-types/index';
+import { ActiveTabService } from '@services/active-tab/active-tab.service';
 
 @Component({
   selector: 'app-case-hearings-table',
   standalone: true,
-  imports: [DataTableComponent, TableRowTemplateDirective, RouterLink, LuxonDatePipe],
+  imports: [DataTableComponent, TableRowTemplateDirective, LuxonDatePipe],
   templateUrl: './case-hearings-table.component.html',
   styleUrl: './case-hearings-table.component.scss',
 })
 export class CaseHearingsTableComponent {
+  router = inject(Router);
+  activeTabService = inject(ActiveTabService);
+
   hearings = input<Hearing[]>([]);
   caseId = input<number>();
   adminScreen = input(false);
@@ -24,4 +28,15 @@ export class CaseHearingsTableComponent {
     { name: 'Courtroom', prop: 'courtroom', sortable: true },
     { name: 'No. of transcripts', prop: 'transcriptCount', sortable: true },
   ];
+
+  goToHearingDetails(hearingId: number): void {
+    const screenId = this.adminScreen() ? 'admin-hearing-details' : 'hearing-screen';
+    this.activeTabService.clearActiveTab(screenId);
+
+    const basePath = this.adminScreen() ? '/admin/case' : '/case';
+
+    this.router.navigate([basePath, this.caseId(), 'hearing', hearingId], {
+      queryParams: { backUrl: `${basePath}/${this.caseId()}` },
+    });
+  }
 }

--- a/src/app/portal/components/hearing/hearing.component.ts
+++ b/src/app/portal/components/hearing/hearing.component.ts
@@ -93,7 +93,7 @@ export class HearingComponent implements OnInit {
   userState = this.route.snapshot.data.userState;
   transcripts: TranscriptsRow[] = [];
   rows: AudioEventRow[] = [];
-  readonly screenId = 'hearingScreen';
+  readonly screenId = 'hearing-screen';
   tab = this.activeTabService.activeTabs()[this.screenId] ?? 'Events and Audio';
   selectedAnnotationsforDeletion: number[] = [];
   statusColours = transcriptStatusTagColours;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-4964

Saved tabs for admin & portal hearing screens are cleared when entering them from hearing results list