### PR TITLE
DMP-2789: Make the corresponding changes for the Frontend after removing the endpoint POST /audio-requests and request_type from the endpoints POST /audio-requests/PLAYBACK and POST /audio-requests/DOWNLOAD. 

### DIFF
--- a/src/app/portal/services/audio-request/audio-request.service.ts
+++ b/src/app/portal/services/audio-request/audio-request.service.ts
@@ -69,11 +69,13 @@ export class AudioRequestService {
   }
 
   requestAudio(audioRequest: PostAudioRequest): Observable<PostAudioResponse> {
-    return this.http.post<PostAudioResponse>(`api/audio-requests/${audioRequest.request_type.toLowerCase()}`, {
-      ...audioRequest,
+    const payload = {
+      hearing_id: audioRequest.hearing_id,
+      requestor: audioRequest.requestor,
       start_time: DateTime.fromISO(audioRequest.start_time).toUTC().toISO(),
       end_time: DateTime.fromISO(audioRequest.end_time).toUTC().toISO(),
-    });
+    }
+    return this.http.post<PostAudioResponse>(`api/audio-requests/${audioRequest.request_type?.toLowerCase()}`, payload);
   }
 
   downloadAudio(transformedMediaId: number, requestType: AudioRequestType): Observable<Blob> {

--- a/src/app/portal/services/audio-request/audio-request.service.ts
+++ b/src/app/portal/services/audio-request/audio-request.service.ts
@@ -75,7 +75,7 @@ export class AudioRequestService {
       start_time: DateTime.fromISO(audioRequest.start_time).toUTC().toISO(),
       end_time: DateTime.fromISO(audioRequest.end_time).toUTC().toISO(),
     }
-    return this.http.post<PostAudioResponse>(`api/audio-requests/${audioRequest.request_type?.toLowerCase()}`, payload);
+    return this.http.post<PostAudioResponse>(`api/audio-requests/${audioRequest.request_type.toLowerCase()}`, payload);
   }
 
   downloadAudio(transformedMediaId: number, requestType: AudioRequestType): Observable<Blob> {

--- a/src/app/portal/services/audio-request/audio-request.service.ts
+++ b/src/app/portal/services/audio-request/audio-request.service.ts
@@ -74,7 +74,7 @@ export class AudioRequestService {
       requestor: audioRequest.requestor,
       start_time: DateTime.fromISO(audioRequest.start_time).toUTC().toISO(),
       end_time: DateTime.fromISO(audioRequest.end_time).toUTC().toISO(),
-    }
+    };
     return this.http.post<PostAudioResponse>(`api/audio-requests/${audioRequest.request_type.toLowerCase()}`, payload);
   }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-2789)


### Change description ###
# Summary of Git Diff for `audio-request.service.ts`

This diff modifies the `requestAudio` method in the `AudioRequestService` class of the `audio-request.service.ts` file. The changes primarily involve restructuring the payload sent in the HTTP POST request.

## Highlights

- **Payload Restructuring**: 
  - The payload created for the HTTP POST request is now explicitly defined using a `const` variable named `payload`.
  - The payload includes `hearing_id`, `requestor`, `start_time`, and `end_time`, with the latter two being converted to UTC format.

- **Use of Optional Chaining**: 
  - The request type is accessed using optional chaining (`request_type?.toLowerCase()`), which adds a layer of safety against potential `undefined` values.

- **Code Readability**: 
  - The changes enhance the readability and maintainability of the code by organizing the data being sent in a more structured way.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
