### PR TITLE
DMP-4955 Added pagination for court log events

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -22,6 +22,9 @@
       "enabled": "EVENT_OBFUSCATION_ENABLED"
     }
   },
+  "pagination": {
+    "courtLogEventsPageLimit": "PAGINATION_COURTLOG_EVENTS_LIMIT"
+  },
   "support": {
     "name": "DARTS_SUPPORT_NAME",
     "emailAddress": "DARTS_SUPPORT_EMAIL_ADDRESS"

--- a/config/default.json
+++ b/config/default.json
@@ -42,6 +42,9 @@
       "enabled": "false"
     }
   },
+  "pagination": {
+    "courtLogEventsPageLimit": 500
+  },
   "caseSearchTimeout": "30 seconds",
   "dynatrace": {
     "scriptUrl": null

--- a/cypress/e2e/functional/case-file-spec.cy.js
+++ b/cypress/e2e/functional/case-file-spec.cy.js
@@ -148,6 +148,20 @@ describe('Case file screen', () => {
         cy.contains('Court log').click();
         cy.get('.govuk-hint').contains('The event text has been anonymised in line with HMCTS policy');
       });
+
+      it('should load initial court log rows and paginate to next page', () => {
+        cy.visit('/case/16');
+        cy.contains('Court log').click();
+
+        cy.get('#court-log-table tbody .govuk-table__row').should('have.length.at.least', 1);
+
+        cy.get('.govuk-pagination__item--current').should('contain', '1');
+
+        cy.get('.govuk-pagination__next a').click();
+
+        cy.get('#court-log-table tbody .govuk-table__row').should('exist');
+        cy.get('.govuk-pagination__item--current').should('contain', '2');
+      });
     });
 
     describe('Transcripts Tab', () => {

--- a/darts-api-stub/cases/case.js
+++ b/darts-api-stub/cases/case.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { DateTime } = require('luxon');
 
 const router = express.Router();
 const { localArray } = require('../localArray');
@@ -877,6 +878,21 @@ router.get('/:caseId/events', (req, res) => {
   switch (caseId) {
     case '10':
       res.status(404).send(resBody404);
+      break;
+    case '16':
+      const manyEvents = Array.from({ length: 1020 }, (_, i) => {
+        const base = events[i % events.length];
+        const timestamp = DateTime.fromISO(base.timestamp).plus({ minutes: i }).toISO();
+
+        return {
+          ...base,
+          id: i + 1,
+          timestamp,
+          name: `Event ${i + 1} name`,
+          text: `Event ${i + 1} text`,
+        };
+      });
+      res.send(manyEvents);
       break;
     default:
       res.send(events);

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -8,5 +8,6 @@ export default () => ({
   environment: config.get('node-env'),
   dynatrace: config.get('dynatrace'),
   features: config.get('features'),
+  pagination: config.get('pagination'),
   caseSearchTimeout: config.get('caseSearchTimeout'),
 });

--- a/src/app/core/components/common/data-table/data-table.component.html
+++ b/src/app/core/components/common/data-table/data-table.component.html
@@ -132,13 +132,21 @@
       </tbody>
     </table>
   </div>
-  <app-pagination
-    *ngIf="pagination"
-    [currentPage]="currentPage"
-    [limit]="pageLimit"
-    [total]="rows.length"
-    (changePage)="onPageChanged($event)"
-  ></app-pagination>
+  @if (pagination && !backendPagination) {
+    <app-pagination
+      [currentPage]="currentPage"
+      [limit]="pageLimit"
+      [total]="rows.length"
+      (changePage)="onPageChanged($event)"
+    />
+  } @else if (backendPagination && totalItems) {
+    <app-pagination
+      [currentPage]="currentPage"
+      [limit]="pageLimit"
+      [total]="totalItems"
+      (changePage)="onPageChanged($event)"
+    />
+  }
 } @else {
   <p id="no-data-message" [attr.aria-label]="noDataMessage" class="govuk-body" tabindex="0">{{ noDataMessage }}</p>
 }

--- a/src/app/core/components/common/data-table/data-table.component.html
+++ b/src/app/core/components/common/data-table/data-table.component.html
@@ -132,18 +132,11 @@
       </tbody>
     </table>
   </div>
-  @if (pagination && !backendPagination) {
+  @if (pagination) {
     <app-pagination
       [currentPage]="currentPage"
       [limit]="pageLimit"
-      [total]="rows.length"
-      (changePage)="onPageChanged($event)"
-    />
-  } @else if (backendPagination && totalItems) {
-    <app-pagination
-      [currentPage]="currentPage"
-      [limit]="pageLimit"
-      [total]="totalItems"
+      [total]="totalItems && backendPagination ? totalItems : rows.length"
       (changePage)="onPageChanged($event)"
     />
   }

--- a/src/app/core/components/common/data-table/data-table.component.spec.ts
+++ b/src/app/core/components/common/data-table/data-table.component.spec.ts
@@ -113,6 +113,26 @@ describe('DataTableComponent', () => {
       // given 4 rows and an irrelevant page limit of 2, we expect all rows to display
       expect(component.pagedRows.length).toEqual(4);
     });
+
+    it('should emit pageChange when backendPagination is true', () => {
+      const pageChangeSpy = jest.spyOn(component.pageChange, 'emit');
+      component.backendPagination = true;
+
+      component.onPageChanged(2);
+
+      expect(pageChangeSpy).toHaveBeenCalledWith(2);
+    });
+
+    it('should update pagedRows when backendPagination is false', () => {
+      component.rows = MOCK_ROWS;
+      component.backendPagination = false;
+      component.pageLimit = 2;
+
+      component.onPageChanged(2);
+
+      expect(component.pagedRows.length).toBe(2);
+      expect(component.pagedRows).toEqual([MOCK_ROWS[2], MOCK_ROWS[3]]);
+    });
   });
 
   describe('Sorting', () => {
@@ -767,6 +787,36 @@ describe('DataTableComponent', () => {
 
       expect(component.sorting.column).toBe('');
     });
+
+    it('should emit sortChange when backendPagination is true', () => {
+      const sortChangeSpy = jest.spyOn(component.sortChange, 'emit');
+
+      component.backendPagination = true;
+      const column = 'case_number';
+
+      component.sortTable(column);
+
+      expect(sortChangeSpy).toHaveBeenCalledWith({
+        sortBy: column,
+        sortOrder: 'asc',
+      });
+    });
+
+    it('should not emit sortChange and sort locally when backendPagination is false', () => {
+      const sortChangeSpy = jest.spyOn(component.sortChange, 'emit');
+      const column = 'courtroom';
+
+      component.backendPagination = false;
+      component.rows = MOCK_ROWS;
+
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+
+      component.sortTable(column);
+
+      const typedRows = component.rows as { courtroom: string }[];
+      expect(sortChangeSpy).not.toHaveBeenCalled();
+      expect(typedRows[0].courtroom <= typedRows[1].courtroom).toBe(true);
+    });
   });
 
   it('should detect valid and invalid numbers in isNumeric for courtroom values', () => {
@@ -903,6 +953,15 @@ describe('DataTableComponent', () => {
         });
         expect(component.currentPage).toEqual(1);
       });
+    });
+
+    it('should assign pagedRows directly when backendPagination is true in ngOnChanges', () => {
+      component.backendPagination = true;
+      component.rows = MOCK_ROWS;
+
+      component.ngOnChanges({ rows: {} } as unknown as SimpleChanges);
+
+      expect(component.pagedRows).toEqual(MOCK_ROWS);
     });
   });
 

--- a/src/app/core/services/app-config/app-config.service.spec.ts
+++ b/src/app/core/services/app-config/app-config.service.spec.ts
@@ -36,6 +36,9 @@ describe('AppConfigService', () => {
         },
       },
       caseSearchTimeout: '30 seconds',
+      pagination: {
+        courtLogEventsPageLimit: 500,
+      },
     };
     jest.spyOn(httpClientSpy, 'get').mockReturnValue(of(testData));
     await appConfigService.loadAppConfig();

--- a/src/app/core/services/app-config/app-config.service.ts
+++ b/src/app/core/services/app-config/app-config.service.ts
@@ -20,6 +20,9 @@ export interface AppConfig {
       enabled: string;
     };
   };
+  pagination: {
+    courtLogEventsPageLimit: number;
+  };
   caseSearchTimeout: string;
 }
 

--- a/src/app/core/services/dynatrace/dynatrace.service.spec.ts
+++ b/src/app/core/services/dynatrace/dynatrace.service.spec.ts
@@ -25,6 +25,9 @@ describe('DynatraceService', () => {
         enabled: 'true',
       },
     },
+    pagination: {
+      courtLogEventsPageLimit: 500,
+    },
     caseSearchTimeout: '30 seconds',
   };
 

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.html
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.html
@@ -5,8 +5,11 @@
   [rows]="events()"
   [columns]="columns"
   [hiddenCaption]="true"
-  [pagination]="pagination"
-  [pageLimit]="eventsPerPage"
+  [backendPagination]="true"
+  [pageLimit]="eventsPerPage()!"
+  [totalItems]="totalItems()"
+  (pageChange)="onPageChange($event)"
+  (sortChange)="onSortChange($event)"
   caption="Court log / events associated with case"
 >
   <ng-template [tableRowTemplate]="events()" let-row>
@@ -16,7 +19,7 @@
       }}</a>
     </td>
     <td>{{ row.timestamp | luxonDate: 'HH:mm:ss' }}</td>
-    <td>{{ row.name }}</td>
+    <td>{{ row.eventName }}</td>
     <td>
       @if (row.isDataAnonymised) {
         <p class="govuk-hint no-margin">The event text has been anonymised in line with HMCTS policy</p>

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.html
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.html
@@ -5,7 +5,8 @@
   [rows]="events()"
   [columns]="columns"
   [hiddenCaption]="true"
-  [pagination]="false"
+  [pagination]="pagination"
+  [pageLimit]="eventsPerPage"
   caption="Court log / events associated with case"
 >
   <ng-template [tableRowTemplate]="events()" let-row>

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.spec.ts
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.spec.ts
@@ -37,41 +37,39 @@ describe('CaseEventsTableComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should enable pagination if events exceed eventsPerPage limit', () => {
-    const mockEvents = Array.from({ length: 10 }, (_, i) => ({
-      id: i + 1,
-      hearing_id: 1,
-      hearing_date: '2024-04-24',
-      timestamp: '2024-04-24T14:30:00Z',
-      name: `Event ${i + 1}`,
-      text: `Text ${i + 1}`,
-    }));
+  it('should emit pageChange when onPageChange is called', () => {
+    const pageChangeSpy = jest.spyOn(component.pageChange, 'emit');
 
-    fixture.componentRef.setInput('events', mockEvents);
-    fixture.detectChanges();
+    component.onPageChange(3);
 
-    component.ngOnInit();
-
-    expect(component.eventsPerPage).toBe(5);
-    expect(component.pagination).toBe(true);
+    expect(pageChangeSpy).toHaveBeenCalledWith(3);
   });
 
-  it('should disable pagination if events are within the eventsPerPage limit', () => {
-    const mockEvents = Array.from({ length: 3 }, (_, i) => ({
-      id: i + 1,
-      hearing_id: 1,
-      hearing_date: '2024-04-24',
-      timestamp: '2024-04-24T14:30:00Z',
-      name: `Event ${i + 1}`,
-      text: `Text ${i + 1}`,
-    }));
+  it('should emit sortChange when a valid sortBy is passed', () => {
+    const sortChangeSpy = jest.spyOn(component.sortChange, 'emit');
 
-    fixture.componentRef.setInput('events', mockEvents);
-    fixture.detectChanges();
+    component.onSortChange({ sortBy: 'hearingDate', sortOrder: 'asc' });
 
-    component.ngOnInit();
+    expect(sortChangeSpy).toHaveBeenCalledWith({
+      sortBy: 'hearingDate',
+      sortOrder: 'asc',
+    });
+  });
 
-    expect(component.eventsPerPage).toBe(5);
-    expect(component.pagination).toBe(false);
+  it('should not emit sortChange when sortBy is invalid', () => {
+    const sortChangeSpy = jest.spyOn(component.sortChange, 'emit');
+
+    component.onSortChange({ sortBy: 'invalidProp', sortOrder: 'desc' });
+
+    expect(sortChangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should define correct column structure', () => {
+    expect(component.columns).toEqual([
+      { name: 'Hearing date', prop: 'hearingDate', sortable: true },
+      { name: 'Time', prop: 'timestamp', sortable: true },
+      { name: 'Event', prop: 'eventName', sortable: true },
+      { name: 'Text', prop: 'text', sortable: false },
+    ]);
   });
 });

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.spec.ts
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { DatePipe } from '@angular/common';
+import { provideRouter } from '@angular/router';
+import { AppConfigService } from '@services/app-config/app-config.service';
 import { CaseEventsTableComponent } from './case-events-table.component';
 
 describe('CaseEventsTableComponent', () => {
@@ -9,6 +12,20 @@ describe('CaseEventsTableComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CaseEventsTableComponent],
+      providers: [
+        {
+          provide: AppConfigService,
+          useValue: {
+            getAppConfig: jest.fn().mockReturnValue({
+              pagination: {
+                courtLogEventsPageLimit: 5,
+              },
+            }),
+          },
+        },
+        DatePipe,
+        provideRouter([]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CaseEventsTableComponent);
@@ -18,5 +35,43 @@ describe('CaseEventsTableComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should enable pagination if events exceed eventsPerPage limit', () => {
+    const mockEvents = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      hearing_id: 1,
+      hearing_date: '2024-04-24',
+      timestamp: '2024-04-24T14:30:00Z',
+      name: `Event ${i + 1}`,
+      text: `Text ${i + 1}`,
+    }));
+
+    fixture.componentRef.setInput('events', mockEvents);
+    fixture.detectChanges();
+
+    component.ngOnInit();
+
+    expect(component.eventsPerPage).toBe(5);
+    expect(component.pagination).toBe(true);
+  });
+
+  it('should disable pagination if events are within the eventsPerPage limit', () => {
+    const mockEvents = Array.from({ length: 3 }, (_, i) => ({
+      id: i + 1,
+      hearing_id: 1,
+      hearing_date: '2024-04-24',
+      timestamp: '2024-04-24T14:30:00Z',
+      name: `Event ${i + 1}`,
+      text: `Text ${i + 1}`,
+    }));
+
+    fixture.componentRef.setInput('events', mockEvents);
+    fixture.detectChanges();
+
+    component.ngOnInit();
+
+    expect(component.eventsPerPage).toBe(5);
+    expect(component.pagination).toBe(false);
   });
 });

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.ts
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, OnInit } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
@@ -8,6 +8,8 @@ import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import { CaseEvent } from '@portal-types/events/case-event';
 import { AppConfigService } from '@services/app-config/app-config.service';
 
+export type CaseEventSortBy = 'hearingDate' | 'timestamp' | 'eventName';
+
 @Component({
   selector: 'app-case-events-table',
   standalone: true,
@@ -15,24 +17,38 @@ import { AppConfigService } from '@services/app-config/app-config.service';
   templateUrl: './case-events-table.component.html',
   styleUrl: './case-events-table.component.scss',
 })
-export class CaseEventsTableComponent implements OnInit {
+export class CaseEventsTableComponent {
   appConfig = inject(AppConfigService);
 
   events = input<CaseEvent[]>([]);
   caseId = input<number>();
+  totalItems = input<number>();
+  eventsPerPage = input<number>();
 
-  eventsPerPage = 500;
-  pagination = false;
+  pageChange = output<number>();
+  sortChange = output<{ sortBy: 'hearingDate' | 'timestamp' | 'eventName'; sortOrder: 'asc' | 'desc' }>();
 
   columns: DatatableColumn[] = [
     { name: 'Hearing date', prop: 'hearingDate', sortable: true },
     { name: 'Time', prop: 'timestamp', sortable: true },
-    { name: 'Event', prop: 'name', sortable: true },
+    { name: 'Event', prop: 'eventName', sortable: true },
     { name: 'Text', prop: 'text', sortable: false },
   ];
 
-  ngOnInit(): void {
-    this.eventsPerPage = this.appConfig.getAppConfig()?.pagination.courtLogEventsPageLimit || 500;
-    this.pagination = this.events().length > this.eventsPerPage;
+  onPageChange(page: number) {
+    this.pageChange.emit(page);
+  }
+
+  onSortChange(sort: { sortBy: string; sortOrder: 'asc' | 'desc' }) {
+    if (!this.isCaseEventSortBy(sort.sortBy)) return;
+
+    this.sortChange.emit({
+      sortBy: sort.sortBy,
+      sortOrder: sort.sortOrder,
+    });
+  }
+
+  private isCaseEventSortBy(value: string): value is CaseEventSortBy {
+    return ['hearingDate', 'timestamp', 'eventName'].includes(value);
   }
 }

--- a/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.ts
+++ b/src/app/portal/components/case/case-file/case-events-table/case-events-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, inject, input, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
@@ -6,6 +6,7 @@ import { DatatableColumn } from '@core-types/index';
 import { TableRowTemplateDirective } from '@directives/table-row-template.directive';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
 import { CaseEvent } from '@portal-types/events/case-event';
+import { AppConfigService } from '@services/app-config/app-config.service';
 
 @Component({
   selector: 'app-case-events-table',
@@ -14,9 +15,14 @@ import { CaseEvent } from '@portal-types/events/case-event';
   templateUrl: './case-events-table.component.html',
   styleUrl: './case-events-table.component.scss',
 })
-export class CaseEventsTableComponent {
+export class CaseEventsTableComponent implements OnInit {
+  appConfig = inject(AppConfigService);
+
   events = input<CaseEvent[]>([]);
   caseId = input<number>();
+
+  eventsPerPage = 500;
+  pagination = false;
 
   columns: DatatableColumn[] = [
     { name: 'Hearing date', prop: 'hearingDate', sortable: true },
@@ -24,4 +30,9 @@ export class CaseEventsTableComponent {
     { name: 'Event', prop: 'name', sortable: true },
     { name: 'Text', prop: 'text', sortable: false },
   ];
+
+  ngOnInit(): void {
+    this.eventsPerPage = this.appConfig.getAppConfig()?.pagination.courtLogEventsPageLimit || 500;
+    this.pagination = this.events().length > this.eventsPerPage;
+  }
 }

--- a/src/app/portal/components/case/case.component.html
+++ b/src/app/portal/components/case/case.component.html
@@ -23,7 +23,14 @@
 
         <div *tab="'Court log'">
           @if (events()) {
-            <app-case-events-table [events]="events()!" [caseId]="caseId" />
+            <app-case-events-table
+              [events]="events()!"
+              [caseId]="caseId"
+              [totalItems]="eventsTotalItems()"
+              [eventsPerPage]="eventsPageLimit"
+              (pageChange)="onPageChange($event)"
+              (sortChange)="onSortChange($event)"
+            />
           } @else {
             <app-loading text="Loading court log..."></app-loading>
           }

--- a/src/app/portal/models/events/case-event.ts
+++ b/src/app/portal/models/events/case-event.ts
@@ -5,7 +5,7 @@ export type CaseEvent = {
   hearingId: number;
   hearingDate: DateTime;
   timestamp: DateTime;
-  name: string;
+  eventName: string;
   text: string;
   isDataAnonymised?: boolean;
 };

--- a/src/app/portal/models/events/paginated-case-events.interface.ts
+++ b/src/app/portal/models/events/paginated-case-events.interface.ts
@@ -1,0 +1,9 @@
+import { CaseEventData } from './case-event-data.interface';
+
+export interface PaginatedCaseEventsData {
+  current_page: number;
+  page_size: number;
+  total_pages: number;
+  total_items: number;
+  data: CaseEventData[];
+}

--- a/src/app/portal/models/events/paginated-case-events.type.ts
+++ b/src/app/portal/models/events/paginated-case-events.type.ts
@@ -1,0 +1,9 @@
+import { CaseEvent } from './case-event';
+
+export type PaginatedCaseEvents = {
+  currentPage: number;
+  pageSize: number;
+  totalPages: number;
+  totalItems: number;
+  data: CaseEvent[];
+};


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-4955

New pagination.courtLogEventsPageLimit configurable value set via PAGINATION_COURTLOG_EVENTS_LIMIT env var. Default value is 500.

Now using query params for pagination on case events