### PR TITLE
DMP-4951: Admin Transciptions Advanced Details tab shows null

### DIFF
--- a/src/app/admin/components/transcripts/view-transcription-document/transcript-file-advanced-detail/transcript-file-advanced-detail.component.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/transcript-file-advanced-detail/transcript-file-advanced-detail.component.ts
@@ -41,7 +41,7 @@ export class TranscriptFileAdvancedDetailComponent implements OnInit {
       'File size': `${this.bytesPipe.transform(document.fileSizeBytes)}MB`,
       'File type': document.fileType,
       Filename: document.fileName,
-      'Date uploaded': `${this.luxonPipe.transform(document.uploadedAt, this.dateFormat) || ''}`,
+      'Date uploaded': `${this.luxonPipe.transform(document.uploadedAt, this.dateFormat) ?? ''}`,
       'Uploaded by': [
         {
           href: `/admin/users/${document.uploadedBy}`,
@@ -54,11 +54,11 @@ export class TranscriptFileAdvancedDetailComponent implements OnInit {
           value: document.lastModifiedByName,
         },
       ],
-      'Date last modified': `${this.luxonPipe.transform(document.lastModifiedAt, this.dateFormat) || ''}`,
+      'Date last modified': `${this.luxonPipe.transform(document.lastModifiedAt, this.dateFormat) ?? ''}`,
       'Transcription hidden?': document.isHidden ? 'Yes' : 'No',
       'Hidden by': document.adminAction?.hiddenByName,
-      'Date hidden': `${this.luxonPipe.transform(document.adminAction?.hiddenAt, this.dateFormat) || ''}`,
-      'Retain until': `${this.luxonPipe.transform(document.retainUntil, this.dateFormat) || ''}`,
+      'Date hidden': `${this.luxonPipe.transform(document.adminAction?.hiddenAt, this.dateFormat) ?? ''}`,
+      'Retain until': `${this.luxonPipe.transform(document.retainUntil, this.dateFormat) ?? ''}`,
     };
   }
 }

--- a/src/app/admin/components/transcripts/view-transcription-document/transcript-file-advanced-detail/transcript-file-advanced-detail.component.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/transcript-file-advanced-detail/transcript-file-advanced-detail.component.ts
@@ -41,7 +41,7 @@ export class TranscriptFileAdvancedDetailComponent implements OnInit {
       'File size': `${this.bytesPipe.transform(document.fileSizeBytes)}MB`,
       'File type': document.fileType,
       Filename: document.fileName,
-      'Date uploaded': `${this.luxonPipe.transform(document.uploadedAt, this.dateFormat)}`,
+      'Date uploaded': `${this.luxonPipe.transform(document.uploadedAt, this.dateFormat) || ''}`,
       'Uploaded by': [
         {
           href: `/admin/users/${document.uploadedBy}`,
@@ -54,11 +54,11 @@ export class TranscriptFileAdvancedDetailComponent implements OnInit {
           value: document.lastModifiedByName,
         },
       ],
-      'Date last modified': `${this.luxonPipe.transform(document.lastModifiedAt, this.dateFormat)}`,
+      'Date last modified': `${this.luxonPipe.transform(document.lastModifiedAt, this.dateFormat) || ''}`,
       'Transcription hidden?': document.isHidden ? 'Yes' : 'No',
       'Hidden by': document.adminAction?.hiddenByName,
-      'Date hidden': `${this.luxonPipe.transform(document.adminAction?.hiddenAt, this.dateFormat)}`,
-      'Retain until': `${this.luxonPipe.transform(document.retainUntil, this.dateFormat)}`,
+      'Date hidden': `${this.luxonPipe.transform(document.adminAction?.hiddenAt, this.dateFormat) || ''}`,
+      'Retain until': `${this.luxonPipe.transform(document.retainUntil, this.dateFormat) || ''}`,
     };
   }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4951)


### Change description ###
# Summary of Git Diff

This Git Diff showcases modifications made to the `transcript-file-advanced-detail.component.ts` file. The primary change involves the handling of date formatting for various document properties, ensuring that if the transformation returns `null`, an empty string is returned instead.

## Highlights
- Updated the formatting of the 'Date uploaded' field to return an empty string if the date transformation is `null`.
- Updated the formatting of the 'Date last modified' field similarly, handling potential `null` values.
- Enhanced the 'Date hidden' field to return an empty string if the date transformation is `null`.
- Adjusted the 'Retain until' field to also return an empty string for `null` values in date transformation.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
