### PR TITLE
DMP-4960: Empty author on transcription comment should not display System user

### DIFF
--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -1,15 +1,15 @@
-import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import {SecurityGroup, User} from '@admin-types/index';
-import {TranscriptionStatus} from '@admin-types/transcription';
-import {TranscriptionAdminDetails} from '@admin-types/transcription/transcription-details';
-import {TranscriptionWorkflow} from '@admin-types/transcription/transcription-workflow';
-import {TranscriptionAdminService} from '@services/transcription-admin/transcription-admin.service';
-import {UserAdminService} from '@services/user-admin/user-admin.service';
-import {DateTime} from 'luxon';
-import {of} from 'rxjs';
-import {TranscriptFacadeService} from './transcript-facade.service';
-import {TimelineItem} from '@core-types/timeline/timeline.type';
+import { SecurityGroup, User } from '@admin-types/index';
+import { TranscriptionStatus } from '@admin-types/transcription';
+import { TranscriptionAdminDetails } from '@admin-types/transcription/transcription-details';
+import { TranscriptionWorkflow } from '@admin-types/transcription/transcription-workflow';
+import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
+import { UserAdminService } from '@services/user-admin/user-admin.service';
+import { DateTime } from 'luxon';
+import { of } from 'rxjs';
+import { TranscriptFacadeService } from './transcript-facade.service';
+import { TimelineItem } from '@core-types/timeline/timeline.type';
 
 describe('TranscriptFacadeService', () => {
   let service: TranscriptFacadeService;
@@ -52,12 +52,12 @@ describe('TranscriptFacadeService', () => {
       getTranscriptionStatuses: jest.fn().mockReturnValue(of([])),
     } as unknown as TranscriptionAdminService;
 
-    fakeUserAdminService = {getUsersById: jest.fn()} as unknown as UserAdminService;
+    fakeUserAdminService = { getUsersById: jest.fn() } as unknown as UserAdminService;
 
     TestBed.configureTestingModule({
       providers: [
-        {provide: UserAdminService, useValue: fakeUserAdminService},
-        {provide: TranscriptionAdminService, useValue: fakeTranscriptionAdminService},
+        { provide: UserAdminService, useValue: fakeUserAdminService },
+        { provide: TranscriptionAdminService, useValue: fakeTranscriptionAdminService },
       ],
     });
     service = TestBed.inject(TranscriptFacadeService);
@@ -71,7 +71,7 @@ describe('TranscriptFacadeService', () => {
     it('should return mapped transcript if requester and courthouseId is present', fakeAsync(() => {
       mockTranscription = {
         ...mockTranscription,
-        requestor: {userId: 1, fullName: 'Test Requester', email: 'email@test.com'},
+        requestor: { userId: 1, fullName: 'Test Requester', email: 'email@test.com' },
         courthouseId: 1,
       };
 
@@ -79,15 +79,15 @@ describe('TranscriptFacadeService', () => {
       jest.spyOn(fakeTranscriptionAdminService, 'getLatestTranscriptionWorkflowActor').mockReturnValue(of(1));
       jest
         .spyOn(fakeUserAdminService, 'getUsersById')
-        .mockReturnValue(of([{id: 1, fullName: 'Test Assignee', emailAddress: 'email@email.com'} as User]));
+        .mockReturnValue(of([{ id: 1, fullName: 'Test Assignee', emailAddress: 'email@email.com' } as User]));
       jest
         .spyOn(fakeTranscriptionAdminService, 'getTranscriptionSecurityGroups')
-        .mockReturnValue(of([{id: 1} as SecurityGroup]));
+        .mockReturnValue(of([{ id: 1 } as SecurityGroup]));
 
       service.getTranscript(1).subscribe((result) =>
         expect(result).toEqual({
           ...mockTranscription,
-          assignedGroups: [{id: 1}],
+          assignedGroups: [{ id: 1 }],
           assignedTo: {
             email: 'email@email.com',
             fullName: 'Test Assignee',
@@ -107,8 +107,8 @@ describe('TranscriptFacadeService', () => {
 
   describe('#getHistory', () => {
     const mockUsers = [
-      {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'} as User,
-      {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'} as User,
+      { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
+      { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User,
     ];
 
     it('should return mapped workflows to timeline', fakeAsync(() => {
@@ -127,7 +127,7 @@ describe('TranscriptFacadeService', () => {
         },
       ];
 
-      const mockStatuses: TranscriptionStatus[] = [{id: 1, displayName: 'Requested', type: 'Requested'}];
+      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
 
       jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
       jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
@@ -139,7 +139,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Requested',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
           },
         ])
       );
@@ -170,7 +170,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
+            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
           },
         ])
       );
@@ -201,7 +201,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
           },
         ])
       );
@@ -232,7 +232,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2022-01-01T00:00:00Z'),
-            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
+            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
           },
         ])
       );
@@ -268,13 +268,13 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment 2'],
             dateTime: DateTime.fromISO('2024-01-01T00:00:00Z'),
-            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
           },
           {
             title: 'Comment',
             descriptionLines: ['Test Comment 1'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
+            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
           },
         ])
       );
@@ -292,7 +292,7 @@ describe('TranscriptFacadeService', () => {
               comment: 'Test Comment',
               commentedAt: DateTime.fromISO('2021-01-01T00:00:00Z'),
               //@ts-expect-error legacy data could be missing commentedAt
-              authorId:  null,
+              authorId: null,
             },
           ],
         },

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -262,6 +262,68 @@ describe('TranscriptFacadeService', () => {
         expect(sortedWorkflows[1].statusId).toBe(1);
       });
 
+      it('if timestamps are equal and one statusId is undefined should have undefined statusId last', () => {
+        const workflows: TranscriptionWorkflow[] = [
+          {
+            workflowActor: 1,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+          {
+            workflowActor: 2,
+            statusId: 1,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+        ];
+
+        const sortedWorkflows = service.sortWorkflowsByTimestampAndStatus(workflows);
+
+        expect(sortedWorkflows[0].workflowActor).toBe(2);
+        expect(sortedWorkflows[1].workflowActor).toBe(1);
+      });
+
+      it('if timestamps are equal and one statusId is undefined should have undefined statusId last', () => {
+        const workflows: TranscriptionWorkflow[] = [
+          {
+            workflowActor: 1,
+            statusId: 1,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+          {
+            workflowActor: 2,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+        ];
+
+        const sortedWorkflows = service.sortWorkflowsByTimestampAndStatus(workflows);
+
+        expect(sortedWorkflows[0].workflowActor).toBe(1);
+        expect(sortedWorkflows[1].workflowActor).toBe(2);
+      });
+
+      it('if timestamps are equal and statusId are both undefined should not change order', () => {
+        const workflows: TranscriptionWorkflow[] = [
+          {
+            workflowActor: 1,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+          {
+            workflowActor: 2,
+            workflowTimestamp: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            comments: [],
+          },
+        ];
+
+        const sortedWorkflows = service.sortWorkflowsByTimestampAndStatus(workflows);
+
+        expect(sortedWorkflows[0].workflowActor).toBe(1);
+        expect(sortedWorkflows[1].workflowActor).toBe(2);
+      });
+
       it('should handle empty workflows array', () => {
         const workflows: TranscriptionWorkflow[] = [];
 

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -214,7 +214,7 @@ describe('TranscriptFacadeService', () => {
           workflowActor: 1,
           workflowTimestamp: DateTime.fromISO('2022-01-01T00:00:00Z'),
           comments: [
-            // @ts-ignore
+            //@ts-expect-error legacy data could be missing commentedAt
             {
               comment: 'Test Comment',
               authorId: 2,

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -138,7 +138,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Requested',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: { id: 1, fullName: 'Test User', emailAddress: 'email@test.com' },
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
           },
         ])
       );

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -105,6 +105,11 @@ describe('TranscriptFacadeService', () => {
   });
 
   describe('#getHistory', () => {
+    const mockUsers = [
+      { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
+      { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User,
+    ];
+
     it('should return mapped workflows to timeline', fakeAsync(() => {
       const mockWorkflows: TranscriptionWorkflow[] = [
         {
@@ -120,8 +125,6 @@ describe('TranscriptFacadeService', () => {
           ],
         },
       ];
-
-      const mockUsers = [{ id: 1, fullName: 'Test User', emailAddress: 'email@test.com' } as User];
 
       const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
 
@@ -156,25 +159,18 @@ describe('TranscriptFacadeService', () => {
         },
       ];
 
-      const mockUsers = [
-        { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
-        { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User];
-
-      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
-
       jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
       jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
-      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionStatuses').mockReturnValue(of(mockStatuses));
 
       service.getHistory(1).subscribe((history) =>
-          expect(history).toEqual([
-            {
-              title: 'Comment',
-              descriptionLines: ['Test Comment'],
-              dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-              user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
-            },
-          ])
+        expect(history).toEqual([
+          {
+            title: 'Comment',
+            descriptionLines: ['Test Comment'],
+            dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+          },
+        ])
       );
       tick();
     }));
@@ -199,15 +195,8 @@ describe('TranscriptFacadeService', () => {
         },
       ];
 
-      const mockUsers = [
-        { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
-        { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User];
-
-      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
-
       jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
       jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
-      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionStatuses').mockReturnValue(of(mockStatuses));
 
       service.getHistory(1).subscribe((history) =>
         expect(history).toEqual([
@@ -222,7 +211,7 @@ describe('TranscriptFacadeService', () => {
             descriptionLines: ['Test Comment 2'],
             dateTime: DateTime.fromISO('2024-01-01T00:00:00Z'),
             user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
-          }
+          },
         ])
       );
       tick();

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -9,7 +9,7 @@ import { UserAdminService } from '@services/user-admin/user-admin.service';
 import { DateTime } from 'luxon';
 import { of } from 'rxjs';
 import { TranscriptFacadeService } from './transcript-facade.service';
-import {TimelineItem} from "@core-types/timeline/timeline.type";
+import { TimelineItem } from '@core-types/timeline/timeline.type';
 
 describe('TranscriptFacadeService', () => {
   let service: TranscriptFacadeService;
@@ -201,7 +201,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user:  { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
           },
         ])
       );
@@ -285,25 +285,25 @@ describe('TranscriptFacadeService', () => {
       it('should sort workflows by dateTime in descending order', () => {
         const timelineItems: TimelineItem[] = [
           {
-            title: "a-title",
+            title: 'a-title',
             dateTime: DateTime.fromISO('2021-01-02T00:00:00Z'),
-            descriptionLines: ["a-description"],
+            descriptionLines: ['a-description'],
             user: {
               id: 1,
-              fullName: "a-name",
-              emailAddress: "a-email"
-            }
+              fullName: 'a-name',
+              emailAddress: 'a-email',
+            },
           },
           {
-            title: "a-title",
+            title: 'a-title',
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ["a-description"],
+            descriptionLines: ['a-description'],
             user: {
               id: 1,
-              fullName: "a-name",
-              emailAddress: "a-email"
-            }
-          }
+              fullName: 'a-name',
+              emailAddress: 'a-email',
+            },
+          },
         ];
 
         const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
@@ -315,27 +315,26 @@ describe('TranscriptFacadeService', () => {
       it('should sort timelineItem by title if dateTime are equal', () => {
         const timelineItems: TimelineItem[] = [
           {
-            title: "b-title",
+            title: 'b-title',
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ["a-description"],
+            descriptionLines: ['a-description'],
             user: {
               id: 1,
-              fullName: "a-name",
-              emailAddress: "a-email"
-            }
+              fullName: 'a-name',
+              emailAddress: 'a-email',
+            },
           },
           {
-            title: "a-title",
+            title: 'a-title',
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ["a-description"],
+            descriptionLines: ['a-description'],
             user: {
               id: 1,
-              fullName: "a-name",
-              emailAddress: "a-email"
-            }
-          }
+              fullName: 'a-name',
+              emailAddress: 'a-email',
+            },
+          },
         ];
-
 
         const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
 

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -1,15 +1,15 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
-import { SecurityGroup, User } from '@admin-types/index';
-import { TranscriptionStatus } from '@admin-types/transcription';
-import { TranscriptionAdminDetails } from '@admin-types/transcription/transcription-details';
-import { TranscriptionWorkflow } from '@admin-types/transcription/transcription-workflow';
-import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
-import { UserAdminService } from '@services/user-admin/user-admin.service';
-import { DateTime } from 'luxon';
-import { of } from 'rxjs';
-import { TranscriptFacadeService } from './transcript-facade.service';
-import { TimelineItem } from '@core-types/timeline/timeline.type';
+import {SecurityGroup, User} from '@admin-types/index';
+import {TranscriptionStatus} from '@admin-types/transcription';
+import {TranscriptionAdminDetails} from '@admin-types/transcription/transcription-details';
+import {TranscriptionWorkflow} from '@admin-types/transcription/transcription-workflow';
+import {TranscriptionAdminService} from '@services/transcription-admin/transcription-admin.service';
+import {UserAdminService} from '@services/user-admin/user-admin.service';
+import {DateTime} from 'luxon';
+import {of} from 'rxjs';
+import {TranscriptFacadeService} from './transcript-facade.service';
+import {TimelineItem} from '@core-types/timeline/timeline.type';
 
 describe('TranscriptFacadeService', () => {
   let service: TranscriptFacadeService;
@@ -52,12 +52,12 @@ describe('TranscriptFacadeService', () => {
       getTranscriptionStatuses: jest.fn().mockReturnValue(of([])),
     } as unknown as TranscriptionAdminService;
 
-    fakeUserAdminService = { getUsersById: jest.fn() } as unknown as UserAdminService;
+    fakeUserAdminService = {getUsersById: jest.fn()} as unknown as UserAdminService;
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: UserAdminService, useValue: fakeUserAdminService },
-        { provide: TranscriptionAdminService, useValue: fakeTranscriptionAdminService },
+        {provide: UserAdminService, useValue: fakeUserAdminService},
+        {provide: TranscriptionAdminService, useValue: fakeTranscriptionAdminService},
       ],
     });
     service = TestBed.inject(TranscriptFacadeService);
@@ -71,7 +71,7 @@ describe('TranscriptFacadeService', () => {
     it('should return mapped transcript if requester and courthouseId is present', fakeAsync(() => {
       mockTranscription = {
         ...mockTranscription,
-        requestor: { userId: 1, fullName: 'Test Requester', email: 'email@test.com' },
+        requestor: {userId: 1, fullName: 'Test Requester', email: 'email@test.com'},
         courthouseId: 1,
       };
 
@@ -79,15 +79,15 @@ describe('TranscriptFacadeService', () => {
       jest.spyOn(fakeTranscriptionAdminService, 'getLatestTranscriptionWorkflowActor').mockReturnValue(of(1));
       jest
         .spyOn(fakeUserAdminService, 'getUsersById')
-        .mockReturnValue(of([{ id: 1, fullName: 'Test Assignee', emailAddress: 'email@email.com' } as User]));
+        .mockReturnValue(of([{id: 1, fullName: 'Test Assignee', emailAddress: 'email@email.com'} as User]));
       jest
         .spyOn(fakeTranscriptionAdminService, 'getTranscriptionSecurityGroups')
-        .mockReturnValue(of([{ id: 1 } as SecurityGroup]));
+        .mockReturnValue(of([{id: 1} as SecurityGroup]));
 
       service.getTranscript(1).subscribe((result) =>
         expect(result).toEqual({
           ...mockTranscription,
-          assignedGroups: [{ id: 1 }],
+          assignedGroups: [{id: 1}],
           assignedTo: {
             email: 'email@email.com',
             fullName: 'Test Assignee',
@@ -107,8 +107,8 @@ describe('TranscriptFacadeService', () => {
 
   describe('#getHistory', () => {
     const mockUsers = [
-      { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
-      { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User,
+      {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'} as User,
+      {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'} as User,
     ];
 
     it('should return mapped workflows to timeline', fakeAsync(() => {
@@ -127,7 +127,7 @@ describe('TranscriptFacadeService', () => {
         },
       ];
 
-      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
+      const mockStatuses: TranscriptionStatus[] = [{id: 1, displayName: 'Requested', type: 'Requested'}];
 
       jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
       jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
@@ -139,7 +139,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Requested',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
+            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
           },
         ])
       );
@@ -170,7 +170,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
           },
         ])
       );
@@ -201,7 +201,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
+            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
           },
         ])
       );
@@ -232,7 +232,7 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2022-01-01T00:00:00Z'),
-            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
           },
         ])
       );
@@ -268,87 +268,119 @@ describe('TranscriptFacadeService', () => {
             title: 'Comment',
             descriptionLines: ['Test Comment 2'],
             dateTime: DateTime.fromISO('2024-01-01T00:00:00Z'),
-            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
+            user: {id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com'},
           },
           {
             title: 'Comment',
             descriptionLines: ['Test Comment 1'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+            user: {id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com'},
           },
         ])
       );
       tick();
     }));
 
-    describe('#sortWorkflowsByTimestampAndStatus', () => {
-      it('should sort workflows by dateTime in descending order', () => {
-        const timelineItems: TimelineItem[] = [
-          {
-            title: 'a-title',
-            dateTime: DateTime.fromISO('2021-01-02T00:00:00Z'),
-            descriptionLines: ['a-description'],
-            user: {
-              id: 1,
-              fullName: 'a-name',
-              emailAddress: 'a-email',
+    it('When user is null comment author should not map', fakeAsync(() => {
+      const mockWorkflows: TranscriptionWorkflow[] = [
+        {
+          //@ts-expect-error legacy data could be missing commentedAt
+          workflowActor: null,
+          workflowTimestamp: DateTime.fromISO('2022-01-01T00:00:00Z'),
+          comments: [
+            {
+              comment: 'Test Comment',
+              commentedAt: DateTime.fromISO('2021-01-01T00:00:00Z'),
+              //@ts-expect-error legacy data could be missing commentedAt
+              authorId:  null,
             },
-          },
+          ],
+        },
+      ];
+
+      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
+      jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
+
+      service.getHistory(1).subscribe((history) =>
+        expect(history).toEqual([
           {
-            title: 'a-title',
+            title: 'Comment',
+            descriptionLines: ['Test Comment'],
             dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ['a-description'],
-            user: {
-              id: 1,
-              fullName: 'a-name',
-              emailAddress: 'a-email',
-            },
+            user: null,
           },
-        ];
-
-        const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
-
-        expect(sortedTimelineItems[0].dateTime.toISO()).toBe('2021-01-02T00:00:00.000+00:00');
-        expect(sortedTimelineItems[1].dateTime.toISO()).toBe('2021-01-01T00:00:00.000+00:00');
-      });
-
-      it('should sort timelineItem by title if dateTime are equal', () => {
-        const timelineItems: TimelineItem[] = [
-          {
-            title: 'b-title',
-            dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ['a-description'],
-            user: {
-              id: 1,
-              fullName: 'a-name',
-              emailAddress: 'a-email',
-            },
+        ])
+      );
+      tick();
+    }));
+  });
+  describe('#sortWorkflowsByTimestampAndStatus', () => {
+    it('should sort workflows by dateTime in descending order', () => {
+      const timelineItems: TimelineItem[] = [
+        {
+          title: 'a-title',
+          dateTime: DateTime.fromISO('2021-01-02T00:00:00Z'),
+          descriptionLines: ['a-description'],
+          user: {
+            id: 1,
+            fullName: 'a-name',
+            emailAddress: 'a-email',
           },
-          {
-            title: 'a-title',
-            dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
-            descriptionLines: ['a-description'],
-            user: {
-              id: 1,
-              fullName: 'a-name',
-              emailAddress: 'a-email',
-            },
+        },
+        {
+          title: 'a-title',
+          dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+          descriptionLines: ['a-description'],
+          user: {
+            id: 1,
+            fullName: 'a-name',
+            emailAddress: 'a-email',
           },
-        ];
+        },
+      ];
 
-        const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
+      const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
 
-        expect(sortedTimelineItems[0].title).toBe('a-title');
-        expect(sortedTimelineItems[1].title).toBe('b-title');
-      });
+      expect(sortedTimelineItems[0].dateTime.toISO()).toBe('2021-01-02T00:00:00.000+00:00');
+      expect(sortedTimelineItems[1].dateTime.toISO()).toBe('2021-01-01T00:00:00.000+00:00');
+    });
 
-      it('should handle empty timelineItem array', () => {
-        const timelineItems: TimelineItem[] = [];
+    it('should sort timelineItem by title if dateTime are equal', () => {
+      const timelineItems: TimelineItem[] = [
+        {
+          title: 'b-title',
+          dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+          descriptionLines: ['a-description'],
+          user: {
+            id: 1,
+            fullName: 'a-name',
+            emailAddress: 'a-email',
+          },
+        },
+        {
+          title: 'a-title',
+          dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+          descriptionLines: ['a-description'],
+          user: {
+            id: 1,
+            fullName: 'a-name',
+            emailAddress: 'a-email',
+          },
+        },
+      ];
 
-        const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
+      const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
 
-        expect(sortedTimelineItems).toEqual([]);
-      });
+      expect(sortedTimelineItems[0].title).toBe('a-title');
+      expect(sortedTimelineItems[1].title).toBe('b-title');
+    });
+
+    it('should handle empty timelineItem array', () => {
+      const timelineItems: TimelineItem[] = [];
+
+      const sortedTimelineItems = service.sortTimelineItemByTimestampAndStatus(timelineItems);
+
+      expect(sortedTimelineItems).toEqual([]);
     });
   });
 });

--- a/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.spec.ts
@@ -141,6 +141,92 @@ describe('TranscriptFacadeService', () => {
       );
       tick();
     }));
+    it('should return mapped comments to timeline if workflow status not present', fakeAsync(() => {
+      const mockWorkflows: TranscriptionWorkflow[] = [
+        {
+          workflowActor: 1,
+          workflowTimestamp: DateTime.fromISO('2022-01-01T00:00:00Z'),
+          comments: [
+            {
+              comment: 'Test Comment',
+              commentedAt: DateTime.fromISO('2021-01-01T00:00:00Z'),
+              authorId: 2,
+            },
+          ],
+        },
+      ];
+
+      const mockUsers = [
+        { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
+        { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User];
+
+      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
+
+      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
+      jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
+      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionStatuses').mockReturnValue(of(mockStatuses));
+
+      service.getHistory(1).subscribe((history) =>
+          expect(history).toEqual([
+            {
+              title: 'Comment',
+              descriptionLines: ['Test Comment'],
+              dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+              user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+            },
+          ])
+      );
+      tick();
+    }));
+
+    it('should return mapped comments to timeline if workflow status not present and multiple comments', fakeAsync(() => {
+      const mockWorkflows: TranscriptionWorkflow[] = [
+        {
+          workflowActor: 1,
+          workflowTimestamp: DateTime.fromISO('2022-01-01T00:00:00Z'),
+          comments: [
+            {
+              comment: 'Test Comment 1',
+              commentedAt: DateTime.fromISO('2021-01-01T00:00:00Z'),
+              authorId: 2,
+            },
+            {
+              comment: 'Test Comment 2',
+              commentedAt: DateTime.fromISO('2024-01-01T00:00:00Z'),
+              authorId: 1,
+            },
+          ],
+        },
+      ];
+
+      const mockUsers = [
+        { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' } as User,
+        { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' } as User];
+
+      const mockStatuses: TranscriptionStatus[] = [{ id: 1, displayName: 'Requested', type: 'Requested' }];
+
+      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionWorkflows').mockReturnValue(of(mockWorkflows));
+      jest.spyOn(fakeUserAdminService, 'getUsersById').mockReturnValue(of(mockUsers));
+      jest.spyOn(fakeTranscriptionAdminService, 'getTranscriptionStatuses').mockReturnValue(of(mockStatuses));
+
+      service.getHistory(1).subscribe((history) =>
+        expect(history).toEqual([
+          {
+            title: 'Comment',
+            descriptionLines: ['Test Comment 1'],
+            dateTime: DateTime.fromISO('2021-01-01T00:00:00Z'),
+            user: { id: 2, fullName: 'Test User 2', emailAddress: 'email2@test.com' },
+          },
+          {
+            title: 'Comment',
+            descriptionLines: ['Test Comment 2'],
+            dateTime: DateTime.fromISO('2024-01-01T00:00:00Z'),
+            user: { id: 1, fullName: 'Test User 1', emailAddress: 'email1@test.com' },
+          }
+        ])
+      );
+      tick();
+    }));
 
     describe('#sortWorkflowsByTimestampAndStatus', () => {
       it('should sort workflows by timestamp in descending order', () => {

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -1,13 +1,13 @@
-import {SecurityGroup, TranscriptionStatus, User} from '@admin-types/index';
-import {TranscriptionAdminDetails} from '@admin-types/transcription/transcription-details';
-import {TranscriptionWorkflow} from '@admin-types/transcription/transcription-workflow';
-import {inject, Injectable} from '@angular/core';
-import {TimelineItem} from '@core-types/index';
-import {TranscriptionAdminService} from '@services/transcription-admin/transcription-admin.service';
-import {UserAdminService} from '@services/user-admin/user-admin.service';
-import {forkJoin, map, of, switchMap} from 'rxjs';
+import { SecurityGroup, TranscriptionStatus, User } from '@admin-types/index';
+import { TranscriptionAdminDetails } from '@admin-types/transcription/transcription-details';
+import { TranscriptionWorkflow } from '@admin-types/transcription/transcription-workflow';
+import { inject, Injectable } from '@angular/core';
+import { TimelineItem } from '@core-types/index';
+import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
+import { UserAdminService } from '@services/user-admin/user-admin.service';
+import { forkJoin, map, of, switchMap } from 'rxjs';
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class TranscriptFacadeService {
   transcriptionAdminService = inject(TranscriptionAdminService);
   userAdminService = inject(UserAdminService);
@@ -20,7 +20,7 @@ export class TranscriptFacadeService {
           workflows: of(workflows),
           users: this.userAdminService.getUsersById(userIds),
           statuses: this.transcriptionAdminService.getTranscriptionStatuses(),
-        }).pipe(map(({workflows, statuses, users}) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
+        }).pipe(map(({ workflows, statuses, users }) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
       })
     );
   }
@@ -58,7 +58,7 @@ export class TranscriptFacadeService {
           users: this.userAdminService.getUsersById(userIds),
           securityGroups: this.transcriptionAdminService.getTranscriptionSecurityGroups(transcription.courthouseId!),
         }).pipe(
-          map(({users, securityGroups}) =>
+          map(({ users, securityGroups }) =>
             this.mapUsersAndSecurityGroupsToTranscription(users, securityGroups, transcription, workflowUserId)
           )
         );
@@ -113,12 +113,14 @@ export class TranscriptFacadeService {
 
     const commentTimelineData = workflows
       .filter((workflow) => workflow.statusId === undefined || !statusMap.get(workflow.statusId))
-      .flatMap((workflow) => workflow.comments.map(value => {
-        return {
-          comment: value,
-          workflow: workflow,
-        };
-      }))
+      .flatMap((workflow) =>
+        workflow.comments.map((value) => {
+          return {
+            comment: value,
+            workflow: workflow,
+          };
+        })
+      )
       .map((data) => {
         const comment = data.comment;
         let user = userMap.get(comment.authorId);

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -104,16 +104,16 @@ export class TranscriptFacadeService {
     statuses: TranscriptionStatus[],
     users: User[]
   ): TimelineItem[] {
-    const userMap = new Map<Number, User>();
+    const userMap = new Map<number, User>();
     users.forEach((user) => userMap.set(user.id, user));
 
-    const statusMap = new Map<Number, TranscriptionStatus>();
+    const statusMap = new Map<number, TranscriptionStatus>();
     statuses.forEach((status) => statusMap.set(status.id, status));
 
     const workflowTimelineData = workflows
       .filter((workflow) => workflow.statusId !== undefined)
       .map((workflow) => ({
-        // @ts-ignore False positive statusId must be present at this stage
+        // @ts-expect-error False positive statusId must be present at this stage
         title: statusMap.get(workflow.statusId).displayName || 'Unknown',
         descriptionLines: workflow.comments.map((c) => c.comment),
         dateTime: workflow.workflowTimestamp,

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -104,16 +104,14 @@ export class TranscriptFacadeService {
     statuses: TranscriptionStatus[],
     users: User[]
   ): TimelineItem[] {
-
-    const userMap = new Map<Number, User>
+    const userMap = new Map<Number, User>();
     users.forEach((user) => userMap.set(user.id, user));
 
-    const statusMap = new Map<Number, TranscriptionStatus>
+    const statusMap = new Map<Number, TranscriptionStatus>();
     statuses.forEach((status) => statusMap.set(status.id, status));
 
-
     const workflowTimelineData = workflows
-      .filter((workflow => workflow.statusId !== undefined))
+      .filter((workflow) => workflow.statusId !== undefined)
       .map((workflow) => ({
         // @ts-ignore False positive statusId must be present at this stage
         title: statusMap.get(workflow.statusId).displayName || 'Unknown',
@@ -123,16 +121,16 @@ export class TranscriptFacadeService {
       }));
 
     const commentTimelineData = workflows
-      .filter((workflow => workflow.statusId === undefined))
+      .filter((workflow) => workflow.statusId === undefined)
       .flatMap((workflow) => workflow.comments)
       .map((comment) => {
         const user = userMap.get(comment.authorId);
-        return ({
+        return {
           title: 'Comment',
           descriptionLines: [comment.comment],
           dateTime: comment.commentedAt,
-          user: user as Pick<User, 'id' | 'fullName' | 'emailAddress'> || null,
-        });
+          user: (user as Pick<User, 'id' | 'fullName' | 'emailAddress'>) || null,
+        };
       });
     return workflowTimelineData.concat(commentTimelineData);
   }

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -1,13 +1,13 @@
-import { SecurityGroup, TranscriptionStatus, User } from '@admin-types/index';
-import { TranscriptionAdminDetails } from '@admin-types/transcription/transcription-details';
-import { TranscriptionWorkflow } from '@admin-types/transcription/transcription-workflow';
-import { inject, Injectable } from '@angular/core';
-import { TimelineItem } from '@core-types/index';
-import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
-import { UserAdminService } from '@services/user-admin/user-admin.service';
-import { forkJoin, map, of, switchMap } from 'rxjs';
+import {SecurityGroup, TranscriptionStatus, User} from '@admin-types/index';
+import {TranscriptionAdminDetails} from '@admin-types/transcription/transcription-details';
+import {TranscriptionWorkflow} from '@admin-types/transcription/transcription-workflow';
+import {inject, Injectable} from '@angular/core';
+import {TimelineItem} from '@core-types/index';
+import {TranscriptionAdminService} from '@services/transcription-admin/transcription-admin.service';
+import {UserAdminService} from '@services/user-admin/user-admin.service';
+import {forkJoin, map, of, switchMap} from 'rxjs';
 
-@Injectable({ providedIn: 'root' })
+@Injectable({providedIn: 'root'})
 export class TranscriptFacadeService {
   transcriptionAdminService = inject(TranscriptionAdminService);
   userAdminService = inject(UserAdminService);
@@ -21,7 +21,7 @@ export class TranscriptFacadeService {
           workflows: of(sortedWorkflows),
           users: this.userAdminService.getUsersById(userIds),
           statuses: this.transcriptionAdminService.getTranscriptionStatuses(),
-        }).pipe(map(({ workflows, statuses, users }) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
+        }).pipe(map(({workflows, statuses, users}) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
       })
     );
   }
@@ -67,7 +67,7 @@ export class TranscriptFacadeService {
           users: this.userAdminService.getUsersById(userIds),
           securityGroups: this.transcriptionAdminService.getTranscriptionSecurityGroups(transcription.courthouseId!),
         }).pipe(
-          map(({ users, securityGroups }) =>
+          map(({users, securityGroups}) =>
             this.mapUsersAndSecurityGroupsToTranscription(users, securityGroups, transcription, workflowUserId)
           )
         );
@@ -111,7 +111,7 @@ export class TranscriptFacadeService {
     statuses.forEach((status) => statusMap.set(status.id, status));
 
     const workflowTimelineData = workflows
-      .filter((workflow) => workflow.statusId !== undefined)
+      .filter((workflow) => workflow.statusId !== undefined && statusMap.get(workflow.statusId))
       .map((workflow) => ({
         // @ts-expect-error False positive statusId must be present at this stage
         title: statusMap.get(workflow.statusId).displayName || 'Unknown',

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -1,13 +1,13 @@
-import {SecurityGroup, TranscriptionStatus, User} from '@admin-types/index';
-import {TranscriptionAdminDetails} from '@admin-types/transcription/transcription-details';
-import {TranscriptionWorkflow} from '@admin-types/transcription/transcription-workflow';
-import {inject, Injectable} from '@angular/core';
-import {TimelineItem} from '@core-types/index';
-import {TranscriptionAdminService} from '@services/transcription-admin/transcription-admin.service';
-import {UserAdminService} from '@services/user-admin/user-admin.service';
-import {forkJoin, map, of, switchMap} from 'rxjs';
+import { SecurityGroup, TranscriptionStatus, User } from '@admin-types/index';
+import { TranscriptionAdminDetails } from '@admin-types/transcription/transcription-details';
+import { TranscriptionWorkflow } from '@admin-types/transcription/transcription-workflow';
+import { inject, Injectable } from '@angular/core';
+import { TimelineItem } from '@core-types/index';
+import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
+import { UserAdminService } from '@services/user-admin/user-admin.service';
+import { forkJoin, map, of, switchMap } from 'rxjs';
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class TranscriptFacadeService {
   transcriptionAdminService = inject(TranscriptionAdminService);
   userAdminService = inject(UserAdminService);
@@ -21,7 +21,7 @@ export class TranscriptFacadeService {
           workflows: of(sortedWorkflows),
           users: this.userAdminService.getUsersById(userIds),
           statuses: this.transcriptionAdminService.getTranscriptionStatuses(),
-        }).pipe(map(({workflows, statuses, users}) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
+        }).pipe(map(({ workflows, statuses, users }) => this.mapWorkflowsToTimeline(workflows, statuses, users)));
       })
     );
   }
@@ -67,7 +67,7 @@ export class TranscriptFacadeService {
           users: this.userAdminService.getUsersById(userIds),
           securityGroups: this.transcriptionAdminService.getTranscriptionSecurityGroups(transcription.courthouseId!),
         }).pipe(
-          map(({users, securityGroups}) =>
+          map(({ users, securityGroups }) =>
             this.mapUsersAndSecurityGroupsToTranscription(users, securityGroups, transcription, workflowUserId)
           )
         );

--- a/src/app/admin/facades/transcript/transcript-facade.service.ts
+++ b/src/app/admin/facades/transcript/transcript-facade.service.ts
@@ -35,9 +35,9 @@ export class TranscriptFacadeService {
       if (b.statusId === undefined && a.statusId === undefined) {
         return 0;
       } else if (b.statusId === undefined) {
-        return 1;
-      } else if (a.statusId === undefined) {
         return -1;
+      } else if (a.statusId === undefined) {
+        return 1;
       } else {
         return b.statusId - a.statusId;
       }

--- a/src/app/admin/models/transcription/transcription-workflow.ts
+++ b/src/app/admin/models/transcription/transcription-workflow.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 
 export type TranscriptionWorkflow = {
   workflowActor: number;
-  statusId: number;
+  statusId?: number;
   workflowTimestamp: DateTime;
   comments: TranscriptionWorkflowComment[];
 };

--- a/src/app/core/components/common/timeline/timeline.component.html
+++ b/src/app/core/components/common/timeline/timeline.component.html
@@ -4,15 +4,17 @@
       <div class="moj-timeline__header">
         <h2 class="moj-timeline__title">{{ item.title }}</h2>
 
-        <p class="moj-timeline__byline">
-          by
-          @if (item.user) {
-            <a class="govuk-link user-link" [routerLink]="['/admin/users', item.user.id]">{{ item.user.fullName }}</a>
-            ({{ item.user.emailAddress }})
-          } @else {
-            System
-          }
-        </p>
+        @if (item.user !== null) {
+          <p class="moj-timeline__byline">
+            by
+            @if (item.user) {
+              <a class="govuk-link user-link" [routerLink]="['/admin/users', item.user.id]">{{ item.user.fullName }}</a>
+              ({{ item.user.emailAddress }})
+            } @else {
+              System
+            }
+          </p>
+        }
       </div>
 
       <p class="moj-timeline__date">

--- a/src/app/core/components/common/timeline/timeline.component.spec.ts
+++ b/src/app/core/components/common/timeline/timeline.component.spec.ts
@@ -1,11 +1,11 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {DatePipe} from '@angular/common';
-import {By} from '@angular/platform-browser';
-import {ActivatedRoute} from '@angular/router';
-import {TimelineItem} from '@core-types/index';
-import {DateTime} from 'luxon';
-import {TimelineComponent} from './timeline.component';
+import { DatePipe } from '@angular/common';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { TimelineItem } from '@core-types/index';
+import { DateTime } from 'luxon';
+import { TimelineComponent } from './timeline.component';
 
 describe('TimelineComponent', () => {
   let component: TimelineComponent;
@@ -48,7 +48,7 @@ describe('TimelineComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TimelineComponent],
-      providers: [{provide: ActivatedRoute, useValue: {}}, DatePipe],
+      providers: [{ provide: ActivatedRoute, useValue: {} }, DatePipe],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TimelineComponent);

--- a/src/app/core/components/common/timeline/timeline.component.spec.ts
+++ b/src/app/core/components/common/timeline/timeline.component.spec.ts
@@ -14,7 +14,6 @@ describe('TimelineComponent', () => {
   // 1 January 2021 at 12:00 AM
   const time = DateTime.fromISO('2021-01-01T00:00:00Z');
 
-  // @ts-ignore
   const MOCK_TIMELINE_ITEMS: TimelineItem[] = [
     {
       dateTime: time,

--- a/src/app/core/components/common/timeline/timeline.component.spec.ts
+++ b/src/app/core/components/common/timeline/timeline.component.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { DatePipe } from '@angular/common';
-import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
-import { TimelineItem } from '@core-types/index';
-import { DateTime } from 'luxon';
-import { TimelineComponent } from './timeline.component';
+import {DatePipe} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {ActivatedRoute} from '@angular/router';
+import {TimelineItem} from '@core-types/index';
+import {DateTime} from 'luxon';
+import {TimelineComponent} from './timeline.component';
 
 describe('TimelineComponent', () => {
   let component: TimelineComponent;
@@ -14,6 +14,7 @@ describe('TimelineComponent', () => {
   // 1 January 2021 at 12:00 AM
   const time = DateTime.fromISO('2021-01-01T00:00:00Z');
 
+  // @ts-ignore
   const MOCK_TIMELINE_ITEMS: TimelineItem[] = [
     {
       dateTime: time,
@@ -35,12 +36,19 @@ describe('TimelineComponent', () => {
         emailAddress: 'beans@toast.com',
       },
     },
+    {
+      dateTime: time,
+      title: 'Title 2',
+      descriptionLines: ['Description 2'],
+      //@ts-expect-error legacy data could be missing user
+      user: null,
+    },
   ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TimelineComponent],
-      providers: [{ provide: ActivatedRoute, useValue: {} }, DatePipe],
+      providers: [{provide: ActivatedRoute, useValue: {}}, DatePipe],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TimelineComponent);
@@ -60,13 +68,17 @@ describe('TimelineComponent', () => {
       const itemElement = timelineItems[i];
       const titleElement = itemElement.query(By.css('.moj-timeline__title')).nativeElement;
       const descriptionElement = itemElement.query(By.css('.moj-timeline__description')).nativeElement;
-      const userElement = itemElement.query(By.css('.moj-timeline__byline')).nativeElement;
+      const userElement = itemElement.query(By.css('.moj-timeline__byline'))?.nativeElement;
       const dateTimeElement = itemElement.query(By.css('.moj-timeline__date')).nativeElement;
 
       expect(titleElement.textContent).toContain(item.title);
       expect(descriptionElement.textContent).toContain(item.descriptionLines[0]);
-      expect(userElement.textContent).toContain(item.user.fullName);
-      expect(userElement.textContent).toContain(item.user.emailAddress);
+      if (item.user !== null) {
+        expect(userElement.textContent).toContain(item.user.fullName);
+        expect(userElement.textContent).toContain(item.user.emailAddress);
+      } else {
+        expect(userElement).toBeUndefined();
+      }
       expect(dateTimeElement.textContent).toContain('1 January 2021 at 12:00 AM');
     });
   });


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4960)


### Change description ###
# Summary of Git Diff

This Git Diff introduces new test cases in the `transcript-facade.service.spec.ts` file to validate the behavior of the `TranscriptFacadeService` when handling comments in transcription workflows. The service now accommodates workflows without a status ID and maps comments to a timeline correctly, both for single and multiple comments.

## Highlights

- **New Test Cases**:
  - Added a test to verify that comments are correctly mapped to the timeline when the workflow status is not present.
  - Another test ensures correct mapping of multiple comments to the timeline without a status.

- **Service Modifications**:
  - Updated `TranscriptFacadeService` to handle workflows with optional `statusId`.
  - Improved the `getHistory` method to filter and map workflows based on their status.
  - Created `userMap` and `statusMap` for efficient lookups when constructing timeline items.

- **HTML Template Changes**:
  - Modified the timeline component's HTML to account for possible null values in user data, ensuring the system displays relevant information without errors.

Overall, the changes enhance the functionality and robustness of the timeline feature in the transcription service by ensuring it handles various scenarios where statuses may be absent.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
