### PR TITLE
DMP-5027 removed admin reference from transcript case link

### DIFF
--- a/src/app/admin/components/transcripts/view-transcript/transcript-details/transcript-details.component.ts
+++ b/src/app/admin/components/transcripts/view-transcript/transcript-details/transcript-details.component.ts
@@ -22,12 +22,10 @@ export class TranscriptDetailsComponent implements OnInit {
   @Input() transcript!: TranscriptionAdminDetails;
 
   requestDetails = {};
-  caseDetails = {};
   currentStatus = {};
 
   ngOnInit(): void {
     this.currentStatus = this.transcriptionAdminService.getCurrentStatusFromTranscript(this.transcript);
     this.requestDetails = this.transcriptionAdminService.getRequestDetailsFromTranscript(this.transcript);
-    this.caseDetails = this.transcriptionService.getCaseDetailsFromTranscript(this.transcript);
   }
 }

--- a/src/app/portal/services/transcription/transcription.service.spec.ts
+++ b/src/app/portal/services/transcription/transcription.service.spec.ts
@@ -497,7 +497,7 @@ describe('TranscriptionService', () => {
       const expectedResult = {
         'Case ID': [
           {
-            href: '/admin/case/1',
+            href: '/case/1',
             value: '123',
           },
         ],
@@ -639,7 +639,7 @@ describe('TranscriptionService', () => {
         caseDetails: {
           'Case ID': [
             {
-              href: '/admin/case/1',
+              href: '/case/1',
               value: '123',
             },
           ],
@@ -702,7 +702,7 @@ describe('TranscriptionService', () => {
         caseDetails: {
           'Case ID': [
             {
-              href: '/admin/case/1',
+              href: '/case/1',
               value: '123',
             },
           ],

--- a/src/app/portal/services/transcription/transcription.service.ts
+++ b/src/app/portal/services/transcription/transcription.service.ts
@@ -147,7 +147,7 @@ export class TranscriptionService {
     return {
       'Case ID': [
         {
-          href: `/admin/case/${transcript.caseId}`,
+          href: `/case/${transcript.caseId}`,
           value: transcript.caseNumber,
         },
       ],


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-5027

Admin transcript screen utilises new govuk summary directive, so old mapping function is not required in this component at all. Mapping function used by portal components updated to reference only portal case link.