### PR TITLE
Handle empty hearing on admin portal transcript documents search

### DIFF
--- a/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.html
+++ b/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.html
@@ -1,5 +1,5 @@
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
-<app-data-table [rows]="rows" [columns]="columns" caption="Transcript search results" [hiddenCaption]="true">
+<app-data-table [rows]="rows" [columns]="columns" caption="Transcript documents search results" [hiddenCaption]="true">
   <ng-template [tableRowTemplate]="rows" let-row>
     <td>
       <a

--- a/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.ts
+++ b/src/app/admin/components/transcripts/search-completed-transcripts-results/search-completed-transcripts-results.component.ts
@@ -39,8 +39,8 @@ export class SearchCompletedTranscriptsResultsComponent implements OnChanges {
       caseId: result.case.id,
       caseNumber: result.case?.caseNumber,
       courthouse: result.courthouse?.displayName,
-      hearingDate: result.hearing.hearingDate,
-      hearingId: result.hearing.id,
+      hearingDate: result.hearing?.hearingDate,
+      hearingId: result.hearing?.id,
       requestMethod: result.isManualTranscription,
       isHidden: result.isHidden,
     }));

--- a/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
+++ b/src/app/admin/components/transcripts/search-transcripts-results/search-transcripts-results.component.html
@@ -1,5 +1,5 @@
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
-<app-data-table [rows]="rows" [columns]="columns" caption="Transcript search results" [hiddenCaption]="true">
+<app-data-table [rows]="rows" [columns]="columns" caption="Transcript requests search results" [hiddenCaption]="true">
   <ng-template [tableRowTemplate]="rows" let-row>
     <td>
       <a class="govuk-link" [routerLink]="[row.id]" [queryParams]="{ backUrl: '/admin/transcripts' }"> {{ row.id }}</a>

--- a/src/app/admin/components/transcripts/transcripts.component.html
+++ b/src/app/admin/components/transcripts/transcripts.component.html
@@ -24,7 +24,7 @@
       />
 
       <div class="results">
-        @if (results) {
+        @if (!isLoadingResults && results) {
           <app-search-transcripts-results [results]="results" />
         }
 
@@ -48,7 +48,7 @@
       />
 
       <div class="results">
-        @if (completedResults) {
+        @if (!isLoadingCompletedResults && completedResults) {
           <app-search-completed-transcripts-results [results]="completedResults" />
         }
 

--- a/src/app/admin/models/transcription/transcription-document-search-result.ts
+++ b/src/app/admin/models/transcription/transcription-document-search-result.ts
@@ -11,7 +11,7 @@ export type TranscriptionDocumentSearchResult = {
     id: number;
     displayName: string;
   };
-  hearing: {
+  hearing?: {
     id?: number;
     hearingDate: DateTime;
   };


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
N/A

### Change description

A client-side error was occurring if the `hearing` object on the transcription-documents search response was empty.

Other miscellaneous tweaks
* Updating table captions to be clearer
* Don't show results table when loading results

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
