### PR TITLE
DMP-4922 cache flag introduced for admin forms

### DIFF
--- a/src/app/admin/components/audio-file/audio-file.component.spec.ts
+++ b/src/app/admin/components/audio-file/audio-file.component.spec.ts
@@ -3,8 +3,10 @@ import { FileHide } from '@admin-types/hidden-reasons/file-hide';
 import { HiddenReason } from '@admin-types/hidden-reasons/hidden-reason';
 import { AudioFile } from '@admin-types/index';
 import { DatePipe } from '@angular/common';
+import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { CaseService } from '@services/case/case.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
 import { TransformedMediaService } from '@services/transformed-media/transformed-media.service';
@@ -167,7 +169,9 @@ describe('AudioFileComponent', () => {
           provide: TranscriptionAdminService,
           useValue: { getHiddenReason: jest.fn().mockReturnValue(of({ displayName: 'because of reasons' })) },
         },
+        { provide: AppInsightsService, useValue: { logEvent: jest.fn() } },
         DatePipe,
+        provideHttpClient(),
       ],
     });
 

--- a/src/app/admin/components/audio-file/audio-file.component.ts
+++ b/src/app/admin/components/audio-file/audio-file.component.ts
@@ -12,6 +12,7 @@ import { HiddenFileBannerComponent } from '@common/hidden-file-banner/hidden-fil
 import { TabsComponent } from '@common/tabs/tabs.component';
 import { TabDirective } from '@directives/tab.directive';
 import { ActiveTabService } from '@services/active-tab/active-tab.service';
+import { AdminSearchService } from '@services/admin-search/admin-search.service';
 import { CaseService } from '@services/case/case.service';
 import { HistoryService } from '@services/history/history.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
@@ -58,6 +59,8 @@ export class AudioFileComponent {
   transcriptionAdminService = inject(TranscriptionAdminService);
   historyService = inject(HistoryService);
   activeTabService = inject(ActiveTabService);
+  searchService = inject(AdminSearchService);
+
   url = inject(Router).url;
 
   tab = computed(() => this.activeTabService.activeTabs()[this.activeTabKey] ?? this.tabNames.basic);
@@ -196,6 +199,8 @@ export class AudioFileComponent {
           })
         )
         .subscribe(() => {
+          this.searchService.fetchNewAudio.set(true);
+
           this.data$ = forkJoin({
             audioFile: this.getAudioFile(),
             associatedCases: this.associatedCases$,

--- a/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.spec.ts
+++ b/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { Event } from '@admin-types/events';
+import { provideHttpClient } from '@angular/common/http';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { EventsFacadeService } from '@facades/events/events-facade.service';
+import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { HeaderService } from '@services/header/header.service';
 import { of } from 'rxjs';
 import { ObfuscateEventTextComponent } from './obfuscate-event-text.component';
@@ -27,7 +29,9 @@ describe('ObfuscateEventTextComponent', () => {
           },
         },
         { provide: HeaderService, useValue: { hideNavigation: jest.fn() } },
+        { provide: AppInsightsService, useValue: { logEvent: jest.fn() } },
         provideRouter([]),
+        provideHttpClient(),
       ],
     });
 

--- a/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.ts
+++ b/src/app/admin/components/events/obfuscate-event-text/obfuscate-event-text.component.ts
@@ -4,6 +4,7 @@ import { Router, RouterLink } from '@angular/router';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { LoadingComponent } from '@common/loading/loading.component';
 import { EventsFacadeService } from '@facades/events/events-facade.service';
+import { AdminSearchService } from '@services/admin-search/admin-search.service';
 import { HeaderService } from '@services/header/header.service';
 import { switchMap } from 'rxjs';
 
@@ -17,6 +18,7 @@ import { switchMap } from 'rxjs';
 export class ObfuscateEventTextComponent implements OnInit {
   router = inject(Router);
   headerService = inject(HeaderService);
+  searchService = inject(AdminSearchService);
   eventsFacadeService = inject(EventsFacadeService);
 
   id = input(0, { transform: numberAttribute });
@@ -28,7 +30,10 @@ export class ObfuscateEventTextComponent implements OnInit {
   }
 
   onContinue() {
-    this.eventsFacadeService.obfuscateEventText(this.id()).subscribe(() => this.navigateBackToEvent());
+    this.eventsFacadeService.obfuscateEventText(this.id()).subscribe(() => {
+      this.searchService.fetchNewEvents.set(true);
+      this.navigateBackToEvent();
+    });
   }
 
   navigateBackToEvent() {

--- a/src/app/admin/components/file-deletion/file-hide-or-delete/file-hide-or-delete.component.spec.ts
+++ b/src/app/admin/components/file-deletion/file-hide-or-delete/file-hide-or-delete.component.spec.ts
@@ -6,6 +6,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LuxonDatePipe } from '@pipes/luxon-date.pipe';
+import { AppInsightsService } from '@services/app-insights/app-insights.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
 import { TransformedMediaService } from '@services/transformed-media/transformed-media.service';
 import { of } from 'rxjs';
@@ -95,6 +96,7 @@ describe('FileHideOrDeleteComponent', () => {
         { provide: ActivatedRoute, useValue: fakeActivatedRoute },
         { provide: TranscriptionAdminService, useValue: fakeTranscriptionAdminService },
         { provide: TransformedMediaService, useValue: fakeTransformedMediaService },
+        { provide: AppInsightsService, useValue: { logEvent: jest.fn() } },
         { provide: Router, useValue: fakeRouter },
         DatePipe,
         LuxonDatePipe,

--- a/src/app/admin/components/file-deletion/file-hide-or-delete/file-hide-or-delete.component.ts
+++ b/src/app/admin/components/file-deletion/file-hide-or-delete/file-hide-or-delete.component.ts
@@ -11,6 +11,7 @@ import { GovukTextareaComponent } from '@common/govuk-textarea/govuk-textarea.co
 import { ValidationErrorSummaryComponent } from '@common/validation-error-summary/validation-error-summary.component';
 import { FileHideOrDeleteFormErrorMessages } from '@constants/file-hide-or-delete-error-messages';
 import { ErrorSummaryEntry } from '@core-types/index';
+import { AdminSearchService } from '@services/admin-search/admin-search.service';
 import { FormService } from '@services/form/form.service';
 import { HeaderService } from '@services/header/header.service';
 import { TranscriptionAdminService } from '@services/transcription-admin/transcription-admin.service';
@@ -42,6 +43,7 @@ export class FileHideOrDeleteComponent implements OnInit {
   transcriptionAdminService = inject(TranscriptionAdminService);
   transformedMediaService = inject(TransformedMediaService);
   formService = inject(FormService);
+  searchService = inject(AdminSearchService);
   title = inject(Title);
 
   errors: ErrorSummaryEntry[] = [];
@@ -126,6 +128,7 @@ export class FileHideOrDeleteComponent implements OnInit {
             })
           )
           .subscribe((associatedAudio) => {
+            this.searchService.fetchNewAudio.set(true);
             this.isSubmitted.set(true);
             // If there are associated audio files, show the associated audio files
             if (associatedAudio.exists) {
@@ -145,6 +148,7 @@ export class FileHideOrDeleteComponent implements OnInit {
   private hideTranscriptionDocument() {
     if (this.hideFormValues) {
       this.transcriptionAdminService.hideTranscriptionDocument(this.id, this.hideFormValues).subscribe(() => {
+        this.transcriptionAdminService.fetchNewCompletedTranscriptions.set(true);
         this.isSubmitted.set(true);
       });
     }

--- a/src/app/admin/components/search/search.component.spec.ts
+++ b/src/app/admin/components/search/search.component.spec.ts
@@ -37,6 +37,9 @@ const fakeAdminSearchService = {
   events: signal([]),
   hearings: signal([]),
   audio: signal([]),
+  fetchNewCases: jest.fn(),
+  fetchNewEvents: jest.fn(),
+  fetchNewAudio: jest.fn(),
 };
 
 describe('SearchComponent', () => {

--- a/src/app/admin/components/search/search.component.ts
+++ b/src/app/admin/components/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { GovukHeadingComponent } from '@common/govuk-heading/govuk-heading.component';
 import { GovukTabsComponent } from '@common/govuk-tabs/govuk-tabs.component';
@@ -35,7 +35,7 @@ import { AdminSearchFormValues, SearchFormComponent } from './search-form/search
     AudioSearchResultsComponent,
   ],
 })
-export class SearchComponent {
+export class SearchComponent implements OnInit {
   courthouseService = inject(CourthouseService);
   searchService = inject(AdminSearchService);
   scrollService = inject(ScrollService);
@@ -52,6 +52,34 @@ export class SearchComponent {
   courthouses = toSignal(this.courthouses$, {
     initialValue: [],
   });
+
+  ngOnInit(): void {
+    this.refetchIfFlagged();
+  }
+
+  private refetchIfFlagged() {
+    const values = this.searchService.formValues();
+    const hasBeenSubmitted = this.searchService.hasFormBeenSubmitted();
+
+    if (!hasBeenSubmitted || !values) return;
+
+    const { resultsFor } = values;
+
+    if (resultsFor === 'Cases' && this.searchService.fetchNewCases()) {
+      this.searchService.getCases(values).subscribe();
+      this.searchService.fetchNewCases.set(false);
+    }
+
+    if (resultsFor === 'Events' && this.searchService.fetchNewEvents()) {
+      this.searchService.getEvents(values).subscribe();
+      this.searchService.fetchNewEvents.set(false);
+    }
+
+    if (resultsFor === 'Audio' && this.searchService.fetchNewAudio()) {
+      this.searchService.getAudioMedia(values).subscribe();
+      this.searchService.fetchNewAudio.set(false);
+    }
+  }
 
   onValidationErrors(errors: ErrorSummaryEntry[]) {
     this.formValidationErrors.set(errors);

--- a/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.spec.ts
+++ b/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.spec.ts
@@ -26,6 +26,7 @@ describe('ChangeTranscriptStatusComponent', () => {
             updateTranscriptionStatus: jest.fn().mockReturnValue(of({})),
             getTranscriptionStatuses: jest.fn(),
             getAllowableTranscriptionStatuses: jest.fn().mockReturnValue(of([])),
+            fetchNewTranscriptions: { set: jest.fn() },
           },
         },
         { provide: HeaderService, useValue: { hideNavigation: jest.fn() } },

--- a/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.ts
+++ b/src/app/admin/components/transcripts/change-transcript-status/change-transcript-status.component.ts
@@ -44,6 +44,7 @@ export class ChangeTranscriptStatusComponent implements OnInit {
     const comments = String(this.form.controls.comments.value);
 
     this.transcriptionAdminService.updateTranscriptionStatus(this.transcriptId, statusId, comments).subscribe(() => {
+      this.transcriptionAdminService.fetchNewTranscriptions.set(true);
       this.router.navigate(['/admin/transcripts', this.transcriptId], { queryParams: { updatedStatus: true } });
     });
   }

--- a/src/app/admin/components/transcripts/transcripts.component.spec.ts
+++ b/src/app/admin/components/transcripts/transcripts.component.spec.ts
@@ -116,6 +116,8 @@ describe('TranscriptsComponent', () => {
             completedSearchResults: signal([]),
             isAdvancedSearch: signal(false),
             hasSearchFormBeenSubmitted$: new BehaviorSubject<boolean>(false),
+            fetchNewTranscriptions: jest.fn(),
+            fetchNewCompletedTranscriptions: jest.fn(),
           },
         },
         {

--- a/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
+++ b/src/app/admin/components/transcripts/view-transcription-document/view-transcription-document.component.ts
@@ -130,6 +130,7 @@ export class ViewTranscriptionDocumentComponent {
   hideOrUnhideFile(document: TranscriptionDocument) {
     if (document.isHidden) {
       this.transcriptionAdminService.unhideTranscriptionDocument(this.transcriptionDocumentId).subscribe(() => {
+        this.transcriptionAdminService.fetchNewCompletedTranscriptions.set(true);
         this.transcription$ = this.getTranscriptionDocument();
       });
     } else {

--- a/src/app/admin/components/transformed-media/change-owner-transformed-media/change-owner-transformed-media.component.spec.ts
+++ b/src/app/admin/components/transformed-media/change-owner-transformed-media/change-owner-transformed-media.component.spec.ts
@@ -27,6 +27,7 @@ describe('ChangeOwnerTransformedMediaComponent', () => {
           provide: TransformedMediaService,
           useValue: {
             changeMediaRequestOwner: jest.fn().mockReturnValue(of({})),
+            fetchNewResults: { set: jest.fn() },
           },
         },
         {

--- a/src/app/admin/components/transformed-media/change-owner-transformed-media/change-owner-transformed-media.component.ts
+++ b/src/app/admin/components/transformed-media/change-owner-transformed-media/change-owner-transformed-media.component.ts
@@ -50,6 +50,7 @@ export class ChangeOwnerTransformedMediaComponent implements OnInit {
     }
 
     this.transformedMediaService.changeMediaRequestOwner(this.mediaRequestId, this.selectedUser.id).subscribe(() => {
+      this.transformedMediaService.fetchNewResults.set(true);
       this.router.navigate(['/admin/transformed-media', this.transformedMediaId], {
         queryParams: { ownerChanged: this.selectedUser?.name.split('(')[0] }, // remove email address from name
       });

--- a/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.spec.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.spec.ts
@@ -78,6 +78,7 @@ describe('SearchTransformedMediaComponent', () => {
       isSearchFormSubmitted: signal<boolean>(false),
       searchResults: signal<TransformedMediaAdmin[]>([]),
       searchFormValues: signal<TransformedMediaSearchFormValues>(defaultFormValues),
+      fetchNewResults: signal<boolean>(false),
     };
 
     fakeUserAdminService = {

--- a/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.ts
+++ b/src/app/admin/components/transformed-media/search-transformed-media/search-transformed-media.component.ts
@@ -1,7 +1,7 @@
 import { TransformedMediaAdmin } from '@admin-types/transformed-media/transformed-media-admin';
 import { TransformedMediaSearchFormValues } from '@admin-types/transformed-media/transformed-media-search-form.values';
 import { CommonModule } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { DataTableComponent } from '@common/data-table/data-table.component';
 import { DeleteComponent } from '@common/delete/delete.component';
@@ -43,7 +43,7 @@ import {
   templateUrl: './search-transformed-media.component.html',
   styleUrl: './search-transformed-media.component.scss',
 })
-export class SearchTransformedMediaComponent {
+export class SearchTransformedMediaComponent implements OnInit {
   transformedMediaService = inject(TransformedMediaService);
   courthouseService = inject(CourthouseService);
   router = inject(Router);
@@ -70,6 +70,22 @@ export class SearchTransformedMediaComponent {
     { name: 'Requested by', prop: 'requestedBy', sortable: true },
     { name: 'Date requested', prop: 'requestedDate', sortable: true },
   ];
+
+  ngOnInit(): void {
+    this.fetchNewTransformedMedia();
+  }
+
+  //Used to fetch new transformed media and bypass caching if an update action has been performed, e.g. owner change
+  private fetchNewTransformedMedia() {
+    const shouldFetch = this.transformedMediaService.fetchNewResults();
+    const formValues = this.transformedMediaService.searchFormValues();
+    const hasBeenSubmitted = this.transformedMediaService.isSearchFormSubmitted();
+
+    if (shouldFetch && formValues && hasBeenSubmitted) {
+      this.onSearch(formValues);
+      this.transformedMediaService.fetchNewResults.set(false);
+    }
+  }
 
   onErrors(errors: ErrorSummaryEntry[]) {
     this.errors.set(errors);

--- a/src/app/admin/services/admin-search/admin-search.service.ts
+++ b/src/app/admin/services/admin-search/admin-search.service.ts
@@ -66,6 +66,11 @@ export class AdminSearchService {
   searchError = signal<string | null>(null);
   isLoading = signal<boolean>(false);
 
+  // TO DO: Implement fetchNewCases setting when admin case retention page is introduced
+  fetchNewCases = signal(false);
+  fetchNewEvents = signal(false);
+  fetchNewAudio = signal(false);
+
   getCases(formValues: AdminSearchFormValues): Observable<AdminCaseSearchResult[]> {
     const requestBody = this.mapAdminSearchFormValuesToSearchRequest(formValues);
     this.logSearchEvent(SearchType.CASE, requestBody);

--- a/src/app/admin/services/transcription-admin/transcription-admin.service.ts
+++ b/src/app/admin/services/transcription-admin/transcription-admin.service.ts
@@ -69,6 +69,8 @@ export class TranscriptionAdminService {
   searchFormValues = signal<TranscriptionSearchFormValues>(defaultFormValues);
   isAdvancedSearch = signal(false);
   hasSearchFormBeenSubmitted$ = new BehaviorSubject<boolean>(false);
+  fetchNewTranscriptions = signal(false);
+  fetchNewCompletedTranscriptions = signal(false);
 
   search(formValues: TranscriptionSearchFormValues): Observable<Transcription[]> {
     const body = this.mapSearchFormValuesToSearchRequest(formValues);

--- a/src/app/admin/services/transformed-media/transformed-media.service.ts
+++ b/src/app/admin/services/transformed-media/transformed-media.service.ts
@@ -45,6 +45,7 @@ export class TransformedMediaService {
   http = inject(HttpClient);
   mappingService = inject(MappingService);
 
+  fetchNewResults = signal(false);
   searchResults = signal<TransformedMediaAdmin[]>([]);
   searchFormValues = signal<TransformedMediaSearchFormValues>({ ...defaultFormValues });
   isSearchFormSubmitted = signal<boolean>(false);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-4922

Cache disable flag introduced for below

- Event obfuscation (admin search)
- Hiding audio files (admin search)
- Changing transformed media owner (transformed media search)
- Changing transcript status (transcript search)
- Hiding/unhiding transcript document (transcript document search)

Added TO DO comment for case retention when admin screen is introduced