### PR TITLE
DMP-5042: (Dev only) Ignore system users in user endpoints

### DIFF
--- a/src/app/admin/components/courthouses/courthouse-record/courthouse-record.component.spec.ts
+++ b/src/app/admin/components/courthouses/courthouse-record/courthouse-record.component.spec.ts
@@ -492,6 +492,7 @@ describe('CourthouseRecordComponent', () => {
           description: 'Stub Active User',
           active: true,
           securityGroupIds: [1],
+          isSystemUser: false,
         },
         {
           id: 2,
@@ -503,6 +504,7 @@ describe('CourthouseRecordComponent', () => {
           description: 'Stub Active User',
           active: true,
           securityGroupIds: [1, 2],
+          isSystemUser: false,
         },
       ];
       const pGroupUserIds: number[] = [1];

--- a/src/app/admin/components/users/user-groups/assign-groups/assign-groups.component.spec.ts
+++ b/src/app/admin/components/users/user-groups/assign-groups/assign-groups.component.spec.ts
@@ -41,6 +41,7 @@ const mockUser: User = {
   active: true,
   securityGroupIds: [1, 2],
   securityGroups: mockGroupsWithRoles,
+  isSystemUser: false,
 };
 
 describe('AssignGroupsComponent', () => {

--- a/src/app/admin/components/users/user-groups/remove-groups/remove-groups.component.spec.ts
+++ b/src/app/admin/components/users/user-groups/remove-groups/remove-groups.component.spec.ts
@@ -33,6 +33,7 @@ const mockUser: User = {
   active: true,
   securityGroupIds: [1, 2],
   securityGroups: mockGroupsWithRoles,
+  isSystemUser: false,
 };
 
 describe('RemoveGroupsComponent', () => {

--- a/src/app/admin/components/users/user-groups/user-groups/user-groups.component.spec.ts
+++ b/src/app/admin/components/users/user-groups/user-groups/user-groups.component.spec.ts
@@ -31,6 +31,7 @@ const mockUser: User = {
   active: true,
   securityGroupIds: [1, 2],
   securityGroups: mockGroupsWithRoles,
+  isSystemUser: false,
 };
 
 describe('UserGroupsComponent', () => {

--- a/src/app/admin/components/users/user-record/user-record.component.spec.ts
+++ b/src/app/admin/components/users/user-record/user-record.component.spec.ts
@@ -28,6 +28,7 @@ describe('UserRecordComponent', () => {
     description: '',
     active: true,
     securityGroupIds: [],
+    isSystemUser: false,
   };
 
   const mockQueryParams = new BehaviorSubject<{ [key: string]: boolean }>({ newUser: false });

--- a/src/app/admin/models/users/user-data.interface.ts
+++ b/src/app/admin/models/users/user-data.interface.ts
@@ -8,4 +8,5 @@ export interface UserData {
   description: string;
   active: boolean;
   security_group_ids: number[];
+  is_system_user?: boolean;
 }

--- a/src/app/admin/models/users/user.type.ts
+++ b/src/app/admin/models/users/user.type.ts
@@ -12,4 +12,5 @@ export type User = {
   active: boolean;
   securityGroupIds: number[];
   securityGroups?: SecurityGroup[];
+  isSystemUser: boolean;
 };

--- a/src/app/admin/services/user-admin/user-admin.service.spec.ts
+++ b/src/app/admin/services/user-admin/user-admin.service.spec.ts
@@ -77,7 +77,7 @@ describe('UserAdminService', () => {
   });
 
   describe('getUsers', () => {
-    it('should fetch and map all users', (done) => {
+    it('should fetch and map all users excluding system users when allowSystemUsers is false', (done) => {
       const mockUsersData: UserData[] = [
         {
           id: 1,
@@ -97,9 +97,22 @@ describe('UserAdminService', () => {
           created_at: '2020-01-01T00:00:00Z',
           full_name: 'John Doe 2',
           email_address: 'john2@example.com',
-          description: 'A test use 2r',
+          description: 'A test user 2',
           active: true,
           security_group_ids: [1, 2],
+          is_system_user: false,
+        },
+        {
+          id: 2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 3',
+          email_address: 'john3@example.com',
+          description: 'A test user 3',
+          active: true,
+          security_group_ids: [1, 2],
+          is_system_user: true,
         },
       ];
 
@@ -114,6 +127,7 @@ describe('UserAdminService', () => {
           description: mockUsersData[0].description,
           active: mockUsersData[0].active,
           securityGroupIds: mockUsersData[0].security_group_ids,
+          isSystemUser: false,
         },
         {
           id: mockUsersData[1].id,
@@ -125,10 +139,100 @@ describe('UserAdminService', () => {
           description: mockUsersData[1].description,
           active: mockUsersData[1].active,
           securityGroupIds: mockUsersData[1].security_group_ids,
+          isSystemUser: false,
         },
       ];
 
       service.getUsers().subscribe((res) => {
+        expect(res).toEqual(mappedUsers);
+        done();
+      });
+
+      const req = httpMock.expectOne(USER_ADMIN_SEARCH_PATH);
+      req.flush(mockUsersData);
+
+      expect(req.request.method).toEqual('POST');
+    });
+
+    it('should fetch and map all users including system users when allowSystemUsers is true', (done) => {
+      const mockUsersData: UserData[] = [
+        {
+          id: 1,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe',
+          email_address: 'john@example.com',
+          description: 'A test user',
+          active: true,
+          security_group_ids: [1, 2],
+        },
+        {
+          id: 2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 2',
+          email_address: 'john2@example.com',
+          description: 'A test user 2',
+          active: true,
+          security_group_ids: [1, 2],
+          is_system_user: false,
+        },
+        {
+          id: 2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 3',
+          email_address: 'john3@example.com',
+          description: 'A test user 3',
+          active: true,
+          security_group_ids: [1, 2],
+          is_system_user: true,
+        },
+      ];
+
+      const mappedUsers: User[] = [
+        {
+          id: mockUsersData[0].id,
+          lastLoginAt: DateTime.fromISO(mockUsersData[0].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[0].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[0].created_at),
+          fullName: mockUsersData[0].full_name,
+          emailAddress: mockUsersData[0].email_address,
+          description: mockUsersData[0].description,
+          active: mockUsersData[0].active,
+          securityGroupIds: mockUsersData[0].security_group_ids,
+          isSystemUser: false,
+        },
+        {
+          id: mockUsersData[1].id,
+          lastLoginAt: DateTime.fromISO(mockUsersData[1].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[1].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[1].created_at),
+          fullName: mockUsersData[1].full_name,
+          emailAddress: mockUsersData[1].email_address,
+          description: mockUsersData[1].description,
+          active: mockUsersData[1].active,
+          securityGroupIds: mockUsersData[1].security_group_ids,
+          isSystemUser: false,
+        },
+        {
+          id: mockUsersData[2].id,
+          lastLoginAt: DateTime.fromISO(mockUsersData[2].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[2].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[2].created_at),
+          fullName: mockUsersData[2].full_name,
+          emailAddress: mockUsersData[2].email_address,
+          description: mockUsersData[2].description,
+          active: mockUsersData[2].active,
+          securityGroupIds: mockUsersData[2].security_group_ids,
+          isSystemUser: true,
+        },
+      ];
+
+      service.getUsers(true).subscribe((res) => {
         expect(res).toEqual(mappedUsers);
         done();
       });
@@ -166,6 +270,7 @@ describe('UserAdminService', () => {
         active: true,
         securityGroupIds: [1, 2],
         securityGroups: mockSecurityGroups,
+        isSystemUser: false,
       };
 
       service.getUser(mockUserId).subscribe((res) => {
@@ -199,6 +304,38 @@ describe('UserAdminService', () => {
         description: 'A user description',
         active: true,
         securityGroupIds: [1, 2, 3],
+        isSystemUser: false,
+      } as unknown as User;
+
+      const result = service['mapUser'](userData);
+      expect(result).toEqual(expectedUser);
+    });
+
+    it('should correctly map system UserData to User', () => {
+      const userData = {
+        id: '1',
+        last_login_at: '2021-01-01T00:00:00.000Z',
+        last_modified_at: '2021-02-01T00:00:00.000Z',
+        created_at: '2021-03-01T00:00:00.000Z',
+        full_name: 'John Doe',
+        email_address: 'john.doe@example.com',
+        description: 'A user description',
+        active: true,
+        security_group_ids: [1, 2, 3],
+        is_system_user: true,
+      } as unknown as UserData;
+
+      const expectedUser = {
+        id: '1',
+        lastLoginAt: DateTime.fromISO(userData.last_login_at),
+        lastModifiedAt: DateTime.fromISO(userData.last_modified_at),
+        createdAt: DateTime.fromISO(userData.created_at),
+        fullName: 'John Doe',
+        emailAddress: 'john.doe@example.com',
+        description: 'A user description',
+        active: true,
+        securityGroupIds: [1, 2, 3],
+        isSystemUser: true,
       } as unknown as User;
 
       const result = service['mapUser'](userData);
@@ -207,7 +344,7 @@ describe('UserAdminService', () => {
   });
 
   describe('searchUsers', () => {
-    it('should return an array of Users', (done) => {
+    it('should return an array of Users excluding system users when allowSystemUsers is false', (done) => {
       const mockQuery: UserSearchFormValues = {
         fullName: 'User',
       };
@@ -231,6 +368,18 @@ describe('UserAdminService', () => {
           email_address: 'dev@local.net',
           active: true,
           security_group_ids: [1, 2, 3],
+          is_system_user: false,
+        },
+        {
+          id: 3,
+          last_login_at: '2022-01-20T00:00:00.000000Z',
+          last_modified_at: '2022-01-20T00:00:00.000000Z',
+          created_at: '2022-01-20T00:00:00.000000Z',
+          full_name: 'Dev User 3',
+          email_address: 'dev3@local.net',
+          active: true,
+          security_group_ids: [1, 2, 3],
+          is_system_user: true,
         },
       ] as UserData[];
 
@@ -245,6 +394,7 @@ describe('UserAdminService', () => {
           description: mockResponse[0].description,
           active: mockResponse[0].active,
           securityGroupIds: mockResponse[0].security_group_ids,
+          isSystemUser: false,
         },
         {
           id: mockResponse[1].id,
@@ -256,10 +406,98 @@ describe('UserAdminService', () => {
           description: mockResponse[1].description,
           active: mockResponse[1].active,
           securityGroupIds: mockResponse[1].security_group_ids,
+          isSystemUser: false,
         },
       ] as User[];
 
       service.searchUsers(mockQuery).subscribe((users) => {
+        expect(users).toEqual(expectedResponse);
+        done();
+      });
+
+      const req = httpMock.expectOne(USER_ADMIN_SEARCH_PATH);
+      expect(req.request.method).toEqual('POST');
+      req.flush(mockResponse); // Simulate a response
+    });
+    it('should return an array of Users including system users when allowSystemUsers is true', (done) => {
+      const mockQuery: UserSearchFormValues = {
+        fullName: 'User',
+      };
+      const mockResponse = [
+        {
+          id: 1,
+          last_login_at: '2024-01-20T00:00:00.000000Z',
+          last_modified_at: '2024-01-20T00:00:00.000000Z',
+          created_at: '2024-01-20T00:00:00.000000Z',
+          full_name: 'Darts User',
+          email_address: 'user@local.net',
+          active: true,
+          security_group_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        },
+        {
+          id: 2,
+          last_login_at: '2023-01-20T00:00:00.000000Z',
+          last_modified_at: '2023-01-20T00:00:00.000000Z',
+          created_at: '2023-01-20T00:00:00.000000Z',
+          full_name: 'Dev User',
+          email_address: 'dev@local.net',
+          active: true,
+          security_group_ids: [1, 2, 3],
+          is_system_user: false,
+        },
+        {
+          id: 3,
+          last_login_at: '2022-01-20T00:00:00.000000Z',
+          last_modified_at: '2022-01-20T00:00:00.000000Z',
+          created_at: '2022-01-20T00:00:00.000000Z',
+          full_name: 'Dev User 3',
+          email_address: 'dev3@local.net',
+          active: true,
+          security_group_ids: [1, 2, 3],
+          is_system_user: true,
+        },
+      ] as UserData[];
+
+      const expectedResponse = [
+        {
+          id: mockResponse[0].id,
+          lastLoginAt: DateTime.fromISO(mockResponse[0].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockResponse[0].last_modified_at),
+          createdAt: DateTime.fromISO(mockResponse[0].created_at),
+          fullName: mockResponse[0].full_name,
+          emailAddress: mockResponse[0].email_address,
+          description: mockResponse[0].description,
+          active: mockResponse[0].active,
+          securityGroupIds: mockResponse[0].security_group_ids,
+          isSystemUser: false,
+        },
+        {
+          id: mockResponse[1].id,
+          lastLoginAt: DateTime.fromISO(mockResponse[1].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockResponse[1].last_modified_at),
+          createdAt: DateTime.fromISO(mockResponse[1].created_at),
+          fullName: mockResponse[1].full_name,
+          emailAddress: mockResponse[1].email_address,
+          description: mockResponse[1].description,
+          active: mockResponse[1].active,
+          securityGroupIds: mockResponse[1].security_group_ids,
+          isSystemUser: false,
+        },
+        {
+          id: mockResponse[2].id,
+          lastLoginAt: DateTime.fromISO(mockResponse[2].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockResponse[2].last_modified_at),
+          createdAt: DateTime.fromISO(mockResponse[2].created_at),
+          fullName: mockResponse[2].full_name,
+          emailAddress: mockResponse[2].email_address,
+          description: mockResponse[2].description,
+          active: mockResponse[2].active,
+          securityGroupIds: mockResponse[2].security_group_ids,
+          isSystemUser: true,
+        },
+      ] as User[];
+
+      service.searchUsers(mockQuery, true).subscribe((users) => {
         expect(users).toEqual(expectedResponse);
         done();
       });
@@ -427,8 +665,9 @@ describe('UserAdminService', () => {
   });
 
   describe('getUsersById', () => {
-    it('should fetch and map all users', () => {
+    it('should fetch and map all users excluding system users when allowSystemUsers is false', () => {
       const mockUserId = 1;
+      const mockUserId2 = 2;
       const mockUsersData: UserData[] = [
         {
           id: mockUserId,
@@ -440,6 +679,18 @@ describe('UserAdminService', () => {
           description: 'A test user',
           active: true,
           security_group_ids: [1, 2],
+        },
+        {
+          id: mockUserId2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 2',
+          email_address: 'email2@email.com',
+          description: 'A test user2',
+          active: true,
+          security_group_ids: [1, 2],
+          is_system_user: true,
         },
       ];
       const mockUserData = mockUsersData[0];
@@ -454,11 +705,76 @@ describe('UserAdminService', () => {
           description: 'A test user',
           active: true,
           securityGroupIds: [1, 2],
+          isSystemUser: false,
         },
       ];
 
       let result = [] as User[];
       service.getUsersById([mockUserId]).subscribe((res: User[]) => (result = res));
+
+      const req = httpMock.expectOne('api/admin/users?user_ids=1');
+      req.flush(mockUsersData);
+
+      expect(result).toEqual(mappedUsers);
+    });
+
+    it('should fetch and map all users including system users when allowSystemUsers is true', () => {
+      const mockUserId = 1;
+      const mockUserId2 = 2;
+      const mockUsersData: UserData[] = [
+        {
+          id: mockUserId,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe',
+          email_address: 'email@email.com',
+          description: 'A test user',
+          active: true,
+          security_group_ids: [1, 2],
+        },
+        {
+          id: mockUserId2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 2',
+          email_address: 'email2@email.com',
+          description: 'A test user2',
+          active: true,
+          security_group_ids: [1, 2],
+          is_system_user: true,
+        },
+      ];
+      const mappedUsers: User[] = [
+        {
+          id: mockUserId,
+          lastLoginAt: DateTime.fromISO(mockUsersData[0].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[0].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[0].created_at),
+          fullName: mockUsersData[0].full_name,
+          emailAddress: mockUsersData[0].email_address,
+          description: mockUsersData[0].description,
+          active: mockUsersData[0].active,
+          securityGroupIds: mockUsersData[0].security_group_ids,
+          isSystemUser: false,
+        },
+        {
+          id: mockUserId2,
+          lastLoginAt: DateTime.fromISO(mockUsersData[1].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[1].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[1].created_at),
+          fullName: mockUsersData[1].full_name,
+          emailAddress: mockUsersData[1].email_address,
+          description: mockUsersData[1].description,
+          active: mockUsersData[1].active,
+          securityGroupIds: mockUsersData[1].security_group_ids,
+          isSystemUser: true,
+        },
+      ];
+
+      let result = [] as User[];
+      service.getUsersById([mockUserId], true).subscribe((res: User[]) => (result = res));
 
       const req = httpMock.expectOne('api/admin/users?user_ids=1');
       req.flush(mockUsersData);

--- a/src/app/admin/services/user-admin/user-admin.service.spec.ts
+++ b/src/app/admin/services/user-admin/user-admin.service.spec.ts
@@ -11,8 +11,6 @@ import { of } from 'rxjs';
 import { USER_ADMIN_PATH, USER_ADMIN_SEARCH_PATH, UserAdminService } from './user-admin.service';
 
 export const ADMIN_GET_USER = 'api/admin/users';
-export const ADMIN_GET_SECURITY_GROUPS = '/api/admin/security-groups';
-export const ADMIN_GET_SECURITY_ROLES = 'api/admin/security-roles';
 
 describe('UserAdminService', () => {
   let service: UserAdminService;
@@ -79,11 +77,10 @@ describe('UserAdminService', () => {
   });
 
   describe('getUsers', () => {
-    it('should fetch and map all users', () => {
-      const mockUserId = 1;
+    it('should fetch and map all users', (done) => {
       const mockUsersData: UserData[] = [
         {
-          id: mockUserId,
+          id: 1,
           last_login_at: '2020-01-01T00:00:00Z',
           last_modified_at: '2020-01-02T00:00:00Z',
           created_at: '2020-01-01T00:00:00Z',
@@ -93,38 +90,58 @@ describe('UserAdminService', () => {
           active: true,
           security_group_ids: [1, 2],
         },
+        {
+          id: 2,
+          last_login_at: '2020-01-01T00:00:00Z',
+          last_modified_at: '2020-01-02T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+          full_name: 'John Doe 2',
+          email_address: 'john2@example.com',
+          description: 'A test use 2r',
+          active: true,
+          security_group_ids: [1, 2],
+        },
       ];
-
-      const mockUserData = mockUsersData[0];
 
       const mappedUsers: User[] = [
         {
-          id: mockUserId,
-          lastLoginAt: DateTime.fromISO(mockUserData.last_login_at),
-          lastModifiedAt: DateTime.fromISO(mockUserData.last_modified_at),
-          createdAt: DateTime.fromISO(mockUserData.created_at),
-          fullName: 'John Doe',
-          emailAddress: 'john@example.com',
-          description: 'A test user',
-          active: true,
-          securityGroupIds: [1, 2],
-          securityGroups: mockSecurityGroups,
+          id: mockUsersData[0].id,
+          lastLoginAt: DateTime.fromISO(mockUsersData[0].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[0].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[0].created_at),
+          fullName: mockUsersData[0].full_name,
+          emailAddress: mockUsersData[0].email_address,
+          description: mockUsersData[0].description,
+          active: mockUsersData[0].active,
+          securityGroupIds: mockUsersData[0].security_group_ids,
+        },
+        {
+          id: mockUsersData[1].id,
+          lastLoginAt: DateTime.fromISO(mockUsersData[1].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockUsersData[1].last_modified_at),
+          createdAt: DateTime.fromISO(mockUsersData[1].created_at),
+          fullName: mockUsersData[1].full_name,
+          emailAddress: mockUsersData[1].email_address,
+          description: mockUsersData[1].description,
+          active: mockUsersData[1].active,
+          securityGroupIds: mockUsersData[1].security_group_ids,
         },
       ];
 
       service.getUsers().subscribe((res) => {
         expect(res).toEqual(mappedUsers);
+        done();
       });
 
       const req = httpMock.expectOne(USER_ADMIN_SEARCH_PATH);
-      req.flush(mockUserData);
+      req.flush(mockUsersData);
 
       expect(req.request.method).toEqual('POST');
     });
   });
 
   describe('getUser', () => {
-    it('should fetch and map user', () => {
+    it('should fetch and map user', (done) => {
       const mockUserId = 1;
       const mockUserData: UserData = {
         id: mockUserId,
@@ -151,13 +168,12 @@ describe('UserAdminService', () => {
         securityGroups: mockSecurityGroups,
       };
 
-      let result!: User;
-
-      service.getUser(mockUserId).subscribe((res) => (result = res));
+      service.getUser(mockUserId).subscribe((res) => {
+        expect(res).toEqual(mappedUser);
+        done();
+      });
 
       httpMock.expectOne(`${ADMIN_GET_USER}/${mockUserId}`).flush(mockUserData);
-
-      expect(result).toEqual(mappedUser);
     });
 
     it('should correctly map UserData to User', () => {
@@ -191,13 +207,14 @@ describe('UserAdminService', () => {
   });
 
   describe('searchUsers', () => {
-    it('should return an array of Users', () => {
+    it('should return an array of Users', (done) => {
       const mockQuery: UserSearchFormValues = {
         fullName: 'User',
       };
       const mockResponse = [
         {
           id: 1,
+          last_login_at: '2024-01-20T00:00:00.000000Z',
           last_modified_at: '2024-01-20T00:00:00.000000Z',
           created_at: '2024-01-20T00:00:00.000000Z',
           full_name: 'Darts User',
@@ -207,6 +224,7 @@ describe('UserAdminService', () => {
         },
         {
           id: 2,
+          last_login_at: '2023-01-20T00:00:00.000000Z',
           last_modified_at: '2023-01-20T00:00:00.000000Z',
           created_at: '2023-01-20T00:00:00.000000Z',
           full_name: 'Dev User',
@@ -216,8 +234,34 @@ describe('UserAdminService', () => {
         },
       ] as UserData[];
 
+      const expectedResponse = [
+        {
+          id: mockResponse[0].id,
+          lastLoginAt: DateTime.fromISO(mockResponse[0].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockResponse[0].last_modified_at),
+          createdAt: DateTime.fromISO(mockResponse[0].created_at),
+          fullName: mockResponse[0].full_name,
+          emailAddress: mockResponse[0].email_address,
+          description: mockResponse[0].description,
+          active: mockResponse[0].active,
+          securityGroupIds: mockResponse[0].security_group_ids,
+        },
+        {
+          id: mockResponse[1].id,
+          lastLoginAt: DateTime.fromISO(mockResponse[1].last_login_at),
+          lastModifiedAt: DateTime.fromISO(mockResponse[1].last_modified_at),
+          createdAt: DateTime.fromISO(mockResponse[1].created_at),
+          fullName: mockResponse[1].full_name,
+          emailAddress: mockResponse[1].email_address,
+          description: mockResponse[1].description,
+          active: mockResponse[1].active,
+          securityGroupIds: mockResponse[1].security_group_ids,
+        },
+      ] as User[];
+
       service.searchUsers(mockQuery).subscribe((users) => {
-        expect(users).toEqual(mockResponse);
+        expect(users).toEqual(expectedResponse);
+        done();
       });
 
       const req = httpMock.expectOne(USER_ADMIN_SEARCH_PATH);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5042)


### Change description ###
# Summary of Git Diff

This Git diff introduces changes to the user management functionality within an application by updating interfaces, types, and service methods. The primary modification is the addition of a new property, `is_system_user`, which allows for more granular control over user data. The changes also include adjustments to unit tests to account for this new property, ensuring that both system and non-system users are properly handled in various scenarios.

## Highlights

- **Interface Updates**:
  - `UserData` interface now includes an optional property `is_system_user`.
  - `User` type now requires the property `isSystemUser`.

- **Service Method Changes**:
  - `getUsers`, `searchUsers`, and `getUsersById` methods updated to accept an `allowSystemUsers` boolean parameter to filter results based on whether to include system users.
  - Mapping functions modified to handle the new `isSystemUser` property.

- **Test Adjustments**:
  - Unit tests for `UserAdminService` updated to test scenarios with and without system users.
  - New user data examples include both system and non-system users to validate functionality.

- **General Improvements**:
  - Enhanced clarity in test descriptions for better understanding of expected behavior based on the inclusion of system users.
  - Consistent use of new properties in assertions and mappings throughout the service methods and their corresponding tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
