### PR TITLE
DMP-5135 increase stop server timeout from 20s to 60s

### DIFF
--- a/charts/darts-portal/Chart.yaml
+++ b/charts/darts-portal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for darts-portal App
 name: darts-portal
 home: https://github.com/hmcts/darts-portal
-version: 0.0.30
+version: 0.0.31
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-portal/values.yaml
+++ b/charts/darts-portal/values.yaml
@@ -3,7 +3,8 @@ nodejs:
   image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
   ingressHost: darts.{{ .Values.global.environment }}.apps.hmcts.net
   aadIdentityName: darts
-  readinessPeriod: 5
+  readinessPeriod: 5 
+  terminationGracePeriodSeconds: 65
   keyVaults:
     darts:
       secrets:

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ async function stopServer() {
   // small delay before closing the server
   // allowing the readiness check to fail and traffic to the pod
   if (NODE_ENV === 'production') {
-    await new Promise((res) => setTimeout(res, 20000));
+    await new Promise((res) => setTimeout(res, 60000));
   }
   console.info('Server closing down');
   server.close(async () => {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-5135

Prevent active connections being added to darts-portal pods scheduled for shut down